### PR TITLE
Add licence headers

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,17 +20,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.9"
-      - name: Install semver
-        run: python -m pip install semver
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1
-        with:
-          workload_identity_provider: projects/1045208284552/locations/global/workloadIdentityPools/vantai-github-actions-pool/providers/vantai-github-actions-provider
-          service_account: default-gha@vantai-analysis.iam.gserviceaccount.com
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
       - name: Configure docker
-        run: gcloud auth configure-docker us-east1-docker.pkg.dev
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
       - name: Get version bump
         id: get-tag
         run: echo "bump=$(python flows/docker.py bump)" >> $GITHUB_OUTPUT
@@ -44,5 +35,5 @@ jobs:
         if: steps.get-tag.outputs.bump != ''
         run: python flows/docker.py test --push
       - name: Save git tag
-        if: steps.get-tag.outputs.bump != ''
+        if: steps.get-tag.outputs.bump != 'skip'
         run: git push origin ${{ steps.get-tag.outputs.bump }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,15 +44,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1
-        with:
-          workload_identity_provider: projects/1045208284552/locations/global/workloadIdentityPools/vantai-github-actions-pool/providers/vantai-github-actions-provider
-          service_account: default-gha@vantai-analysis.iam.gserviceaccount.com
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
       - name: Configure docker
-        run: gcloud auth configure-docker us-east1-docker.pkg.dev
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v41
@@ -65,7 +58,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed != 'true'
         run: python flows/docker.py pull
       - name: Build image
-        run: python flows/docker.py build --push
+        run: python flows/docker.py build
       - name: Run test image
         run: python flows/docker.py test
       - name: Copy coverage

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -55,7 +55,7 @@ jobs:
         run: gcloud auth configure-docker us-east1-docker.pkg.dev
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v39
+        uses: tj-actions/changed-files@v41
         with:
           files: dockerfiles/base/*
       - name: Pull base image and build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,23 @@
 services:
 
   base:
-    image: ${IMAGE_REPO:-docker.io}/plinder-base:${BASE_TAG:-latest}
+    image: ${IMAGE_REPO:-ghcr.io/plinder-org}/plinder-base:${BASE_TAG:-latest}
     build:
       context: ./dockerfiles/base
 
   plinder:
-    image: ${IMAGE_REPO:-docker.io}/plinder:${BUILD_TAG:-latest}
+    image: ${IMAGE_REPO:-ghcr.io/plinder-org}/plinder:${BUILD_TAG:-latest}
     build:
       context: .
       dockerfile: ./dockerfiles/main/Dockerfile
       args:
-        BASE_IMAGE: ${IMAGE_REPO:-docker.io}/plinder-base
+        BASE_IMAGE: ${IMAGE_REPO:-ghcr.io/plinder-org}/plinder-base
         BASE_TAG: ${BASE_TAG:-latest}
     depends_on:
       - base
 
   test:
-    image: ${IMAGE_REPO:-docker.io}/plinder:${BUILD_TAG:-latest}
+    image: ${IMAGE_REPO:-ghcr.io/plinder-org}/plinder:${BUILD_TAG:-latest}
     depends_on:
       - plinder
     volumes:

--- a/dockerfiles/base/requirements.txt
+++ b/dockerfiles/base/requirements.txt
@@ -18,7 +18,7 @@ boto3==1.34.134           # via metaflow
 botocore==1.34.134        # via boto3, s3transfer
 build==0.9.0              # via plinder (pyproject.toml)
 cachetools==5.3.3         # via google-auth, tox
-certifi==2024.6.2         # via kubernetes, requests
+certifi==2024.7.4         # via kubernetes, requests
 cffi==1.16.0              # via cryptography
 chardet==5.2.0            # via tox
 charset-normalizer==3.3.2  # via requests

--- a/flows/data_ingest.py
+++ b/flows/data_ingest.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 """
 The filestore instance name is: plinder-data-gen.
 

--- a/flows/data_ingest_report.py
+++ b/flows/data_ingest_report.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 """
 The filestore instance name is: plinder-data-gen.
 """

--- a/flows/docker.py
+++ b/flows/docker.py
@@ -18,41 +18,6 @@ logging.basicConfig(level=logging.INFO)
 LOG = logging.getLogger("doc")
 
 
-def query_gar(image: str, tag: str) -> List[str]:
-    """
-    Simply check the artifact registry for a particular image.
-    This is an eager validation to ensure that a flow does not
-    get stuck in a ImagePullBackOff state because k8s cannot find
-    the image in the artifact registry.
-
-    Parameters
-    ----------
-    image : str
-        image name leading up to the tag
-    tag : str
-        image tag itself
-
-    Returns
-    -------
-    out : List[str]
-        the output of the gcloud command for downstream processing
-    """
-    cmd = " ".join(
-        [
-            "gcloud",
-            "artifacts",
-            "docker",
-            "images",
-            "list",
-            image,
-            "--include-tags",
-            "--format='(tags)'",
-            f"--filter=tags~{tag}",
-        ]
-    )
-    return check_output(cmd, stderr=PIPE, text=True, shell=True).splitlines()
-
-
 def get_dev_tag() -> str:
     """
     Get the current git describe which includes base image tag
@@ -171,29 +136,9 @@ def get_env(tag: str | None = None) -> dict[str, str]:
             "BASE_TAG": base_tag,
             "IMAGE_REPO": image_repo,
             "BUILD_TAG": build_tag,
+            "INDEX_URL": "https://pypi.org/simple",
         },
     }
-
-
-def get_flow_image() -> str:
-    """
-    metaflow integration to ensure the image passed to the kubernetes
-    decorator is in sync with the current dev tag
-    """
-    image = get_image()
-    tag = "latest"
-    # if we're already in kubernetes then image
-    # doesn't really matter anymore so short circuit
-    if "METAFLOW_KUBERNETES_WORKLOAD" in environ:
-        return f"{image}:{tag}"
-    tag = get_dev_tag()
-    if not len(query_gar(image, tag)):
-        build_image(push=True)
-    return f"{image}:{tag}"
-
-
-def get_index_url() -> str:
-    return "https://pypi.org/simple"
 
 
 def pull_base_image(build: bool = False, promote: bool = False) -> None:
@@ -212,7 +157,6 @@ def pull_base_image(build: bool = False, promote: bool = False) -> None:
     cmd = [docker, "compose", "pull", "base", "--quiet"]
     Proc(cmd, env=env).execute()
     if build:
-        env["INDEX_URL"] = get_index_url()
         cmd = [
             docker,
             "build",
@@ -272,16 +216,13 @@ def build_image(tag: str | None = None, push: bool = False) -> str:
     env = get_env(tag)
     image = f"{env['IMAGE_REPO']}/plinder"
     build_tag = env["BUILD_TAG"]
-    if tag is None and len(query_gar(image, build_tag)):
-        return f"{image}:{build_tag}"
-    env["INDEX_URL"] = get_index_url()
     cmd = [
         docker,
         "build",
         "-f",
         "dockerfiles/main/Dockerfile",
         "-t",
-        f"{env['IMAGE_REPO']}/plinder:{env['BUILD_TAG']}",
+        f"{env['IMAGE_REPO']}/plinder:{build_tag}",
         "--secret",
         "id=INDEX_URL",
         "--build-arg",
@@ -319,8 +260,6 @@ def test_image(
         the arguments to pass to the image
     """
     env = get_env(tag)
-    # if not push:
-    #     build_image(tag=tag)
     docker = get_docker()
     cmd = [docker, "compose", "run", "test"]
     if args is not None and len(args):

--- a/flows/docker.py
+++ b/flows/docker.py
@@ -127,11 +127,10 @@ def get_image() -> str:
     """
     Minimize the diff if any of this changes
     """
-    url = "us-east1-docker.pkg.dev"
-    project = "vantai-analysis"
-    registry = "vantai-rnd-images"
+    url = "ghcr.io"
+    organization = "plinder-org"
     image_name = "plinder"
-    return f"{url}/{project}/{registry}/{image_name}"
+    return f"{url}/{organization}/{image_name}"
 
 
 def get_docker() -> str:
@@ -194,14 +193,7 @@ def get_flow_image() -> str:
 
 
 def get_index_url() -> str:
-    try:
-        token = check_output(
-            ["gcloud", "auth", "print-access-token"], text=True
-        ).strip()
-        return f"https://oauth2accesstoken:{token}@us-east1-python.pkg.dev/vantai-analysis/internal/simple"
-    except Exception as e:
-        LOG.error(f"error getting token: {e}")
-        return "https://pypi.org/simple"
+    return "https://pypi.org/simple"
 
 
 def pull_base_image(build: bool = False, promote: bool = False) -> None:

--- a/flows/docker.py
+++ b/flows/docker.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import logging

--- a/flows/proc.py
+++ b/flows/proc.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 import io
 import logging
 from subprocess import PIPE, STDOUT, Popen

--- a/flows/report.py
+++ b/flows/report.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 import os
 import json
 from dataclasses import dataclass, asdict

--- a/flows/split_eval.py
+++ b/flows/split_eval.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 
 from __future__ import annotations
 

--- a/src/plinder-core/plinder/core/__init__.py
+++ b/src/plinder-core/plinder/core/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 try:
     import geotite
 except ImportError:

--- a/src/plinder-core/plinder/core/_version.py
+++ b/src/plinder-core/plinder/core/_version.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 """
 Module for supplying version information.
 

--- a/src/plinder-core/plinder/core/index/__init__.py
+++ b/src/plinder-core/plinder/core/index/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0

--- a/src/plinder-core/plinder/core/index/system.py
+++ b/src/plinder-core/plinder/core/index/system.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0

--- a/src/plinder-core/plinder/core/index/utils.py
+++ b/src/plinder-core/plinder/core/index/utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 from json import load

--- a/src/plinder-core/plinder/core/loader/__init__.py
+++ b/src/plinder-core/plinder/core/loader/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0

--- a/src/plinder-core/plinder/core/loader/loader.py
+++ b/src/plinder-core/plinder/core/loader/loader.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0

--- a/src/plinder-core/plinder/core/scores/__init__.py
+++ b/src/plinder-core/plinder/core/scores/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from .clusters import query_clusters
 from .ligand import query_ligand_similarity
 from .protein import query_protein_similarity

--- a/src/plinder-core/plinder/core/scores/clusters.py
+++ b/src/plinder-core/plinder/core/scores/clusters.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import pandas as pd

--- a/src/plinder-core/plinder/core/scores/index.py
+++ b/src/plinder-core/plinder/core/scores/index.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import pandas as pd

--- a/src/plinder-core/plinder/core/scores/ligand.py
+++ b/src/plinder-core/plinder/core/scores/ligand.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import pandas as pd

--- a/src/plinder-core/plinder/core/scores/protein.py
+++ b/src/plinder-core/plinder/core/scores/protein.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import pandas as pd

--- a/src/plinder-core/plinder/core/scores/query.py
+++ b/src/plinder-core/plinder/core/scores/query.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 from pathlib import Path

--- a/src/plinder-core/plinder/core/system/__init__.py
+++ b/src/plinder-core/plinder/core/system/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0

--- a/src/plinder-core/plinder/core/system/system.py
+++ b/src/plinder-core/plinder/core/system/system.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from typing import Any, Optional
 
 from omegaconf import DictConfig

--- a/src/plinder-core/plinder/core/system/utils.py
+++ b/src/plinder-core/plinder/core/system/utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from typing import Any, Optional, Union
 
 from omegaconf import DictConfig

--- a/src/plinder-core/plinder/core/utils/__init__.py
+++ b/src/plinder-core/plinder/core/utils/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0

--- a/src/plinder-core/plinder/core/utils/config.py
+++ b/src/plinder-core/plinder/core/utils/config.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from dataclasses import dataclass, field
 from functools import partial
 from hashlib import md5

--- a/src/plinder-core/plinder/core/utils/cpl.py
+++ b/src/plinder-core/plinder/core/utils/cpl.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from functools import wraps
 from time import sleep
 from typing import Callable, Optional, TypeVar, Union, overload

--- a/src/plinder-core/plinder/core/utils/dec.py
+++ b/src/plinder-core/plinder/core/utils/dec.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from functools import wraps
 from time import time
 from typing import Any, Callable, TypeVar

--- a/src/plinder-core/plinder/core/utils/gcs.py
+++ b/src/plinder-core/plinder/core/utils/gcs.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from concurrent.futures import ThreadPoolExecutor
 from functools import wraps
 from pathlib import Path

--- a/src/plinder-core/plinder/core/utils/log.py
+++ b/src/plinder-core/plinder/core/utils/log.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import inspect

--- a/src/plinder-core/plinder/core/utils/schemas.py
+++ b/src/plinder-core/plinder/core/utils/schemas.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 import pyarrow as pa
 
 PROTEIN_SIMILARITY_SCHEMA = pa.schema(

--- a/src/plinder-core/plinder/core/utils/unpack.py
+++ b/src/plinder-core/plinder/core/utils/unpack.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 from pathlib import Path

--- a/src/plinder-data/plinder/data/__init__.py
+++ b/src/plinder-data/plinder/data/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 """Namespace package root for plinder-data."""
 from pathlib import Path
 

--- a/src/plinder-data/plinder/data/_version.py
+++ b/src/plinder-data/plinder/data/_version.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 """
 Module for supplying version information.
 

--- a/src/plinder-data/plinder/data/clusters.py
+++ b/src/plinder-data/plinder/data/clusters.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 import logging
 import os
 from pathlib import Path

--- a/src/plinder-data/plinder/data/common/__init__.py
+++ b/src/plinder-data/plinder/data/common/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from plinder.data.common.log import setup_logger
 
 __all__ = [

--- a/src/plinder-data/plinder/data/common/_version.py
+++ b/src/plinder-data/plinder/data/common/_version.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0

--- a/src/plinder-data/plinder/data/common/constants.py
+++ b/src/plinder-data/plinder/data/common/constants.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 from pathlib import Path

--- a/src/plinder-data/plinder/data/common/log.py
+++ b/src/plinder-data/plinder/data/common/log.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from plinder.core.utils.log import setup_logger
 
 LOG = setup_logger(__name__)

--- a/src/plinder-data/plinder/data/compare_split_props.py
+++ b/src/plinder-data/plinder/data/compare_split_props.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import multiprocessing

--- a/src/plinder-data/plinder/data/databases.py
+++ b/src/plinder-data/plinder/data/databases.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 import json
 from pathlib import Path
 import subprocess as sp

--- a/src/plinder-data/plinder/data/final_structure_qc.py
+++ b/src/plinder-data/plinder/data/final_structure_qc.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import json

--- a/src/plinder-data/plinder/data/get_system_annotations.py
+++ b/src/plinder-data/plinder/data/get_system_annotations.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import json

--- a/src/plinder-data/plinder/data/leakage.py
+++ b/src/plinder-data/plinder/data/leakage.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from pathlib import Path
 
 import pandas as pd

--- a/src/plinder-data/plinder/data/pipeline/__init__.py
+++ b/src/plinder-data/plinder/data/pipeline/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0

--- a/src/plinder-data/plinder/data/pipeline/config.py
+++ b/src/plinder-data/plinder/data/pipeline/config.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 import hashlib
 import json
 from dataclasses import dataclass, field

--- a/src/plinder-data/plinder/data/pipeline/io.py
+++ b/src/plinder-data/plinder/data/pipeline/io.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 """
 Wrap all network requests in a retry decorator
 and use a convention of looking for a file in a

--- a/src/plinder-data/plinder/data/pipeline/mpqueue.py
+++ b/src/plinder-data/plinder/data/pipeline/mpqueue.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 #!/usr/bin/env python
 
 import time

--- a/src/plinder-data/plinder/data/pipeline/pipeline.py
+++ b/src/plinder-data/plinder/data/pipeline/pipeline.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from pathlib import Path
 from typing import Optional, Any
 

--- a/src/plinder-data/plinder/data/pipeline/tasks.py
+++ b/src/plinder-data/plinder/data/pipeline/tasks.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 import os
 from textwrap import dedent
 from pathlib import Path

--- a/src/plinder-data/plinder/data/pipeline/transform.py
+++ b/src/plinder-data/plinder/data/pipeline/transform.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 import tarfile
 from pathlib import Path
 

--- a/src/plinder-data/plinder/data/pipeline/utils.py
+++ b/src/plinder-data/plinder/data/pipeline/utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 from json import dumps

--- a/src/plinder-data/plinder/data/save_linked_structures.py
+++ b/src/plinder-data/plinder/data/save_linked_structures.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import json

--- a/src/plinder-data/plinder/data/smallmolecules.py
+++ b/src/plinder-data/plinder/data/smallmolecules.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 # This script contains all funcs related to small molecules.
 from __future__ import annotations
 

--- a/src/plinder-data/plinder/data/splits.py
+++ b/src/plinder-data/plinder/data/splits.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from collections import Counter, defaultdict
 from copy import copy
 from dataclasses import dataclass, field

--- a/src/plinder-data/plinder/data/structure/__init__.py
+++ b/src/plinder-data/plinder/data/structure/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0

--- a/src/plinder-data/plinder/data/structure/atoms.py
+++ b/src/plinder-data/plinder/data/structure/atoms.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import gzip

--- a/src/plinder-data/plinder/data/structure/contacts.py
+++ b/src/plinder-data/plinder/data/structure/contacts.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 from itertools import combinations

--- a/src/plinder-data/plinder/data/structure/models.py
+++ b/src/plinder-data/plinder/data/structure/models.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 from enum import Enum

--- a/src/plinder-data/plinder/data/utils/__init__.py
+++ b/src/plinder-data/plinder/data/utils/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0

--- a/src/plinder-data/plinder/data/utils/annotations/__init__.py
+++ b/src/plinder-data/plinder/data/utils/annotations/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0

--- a/src/plinder-data/plinder/data/utils/annotations/aggregate_annotations.py
+++ b/src/plinder-data/plinder/data/utils/annotations/aggregate_annotations.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import json

--- a/src/plinder-data/plinder/data/utils/annotations/extras.py
+++ b/src/plinder-data/plinder/data/utils/annotations/extras.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import glob

--- a/src/plinder-data/plinder/data/utils/annotations/get_ligand_validation.py
+++ b/src/plinder-data/plinder/data/utils/annotations/get_ligand_validation.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field

--- a/src/plinder-data/plinder/data/utils/annotations/get_similarity_scores.py
+++ b/src/plinder-data/plinder/data/utils/annotations/get_similarity_scores.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import shutil

--- a/src/plinder-data/plinder/data/utils/annotations/interaction_utils.py
+++ b/src/plinder-data/plinder/data/utils/annotations/interaction_utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import gzip

--- a/src/plinder-data/plinder/data/utils/annotations/interface_gap.py
+++ b/src/plinder-data/plinder/data/utils/annotations/interface_gap.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 from pathlib import Path

--- a/src/plinder-data/plinder/data/utils/annotations/ligand_utils.py
+++ b/src/plinder-data/plinder/data/utils/annotations/ligand_utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import logging

--- a/src/plinder-data/plinder/data/utils/annotations/mmpdb_utils.py
+++ b/src/plinder-data/plinder/data/utils/annotations/mmpdb_utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import os

--- a/src/plinder-data/plinder/data/utils/annotations/protein_utils.py
+++ b/src/plinder-data/plinder/data/utils/annotations/protein_utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import gzip

--- a/src/plinder-data/plinder/data/utils/annotations/rdkit_utils.py
+++ b/src/plinder-data/plinder/data/utils/annotations/rdkit_utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import logging

--- a/src/plinder-data/plinder/data/utils/annotations/save_utils.py
+++ b/src/plinder-data/plinder/data/utils/annotations/save_utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import json

--- a/src/plinder-data/plinder/data/utils/cluster.py
+++ b/src/plinder-data/plinder/data/utils/cluster.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 import networkx as nx
 import numpy as np
 import pandas as pd

--- a/src/plinder-data/plinder/data/utils/diffdock_utils.py
+++ b/src/plinder-data/plinder/data/utils/diffdock_utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 # mypy: disable-error-code="no-untyped-def, no-untyped-call, attr-defined, assignment, arg-type, var-annotated"
 
 from plinder.data.common.log import setup_logger

--- a/src/plinder-data/plinder/data/utils/tanimoto.py
+++ b/src/plinder-data/plinder/data/utils/tanimoto.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Any
 

--- a/src/plinder-eval/plinder/eval/docking/__init__.py
+++ b/src/plinder-eval/plinder/eval/docking/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0

--- a/src/plinder-eval/plinder/eval/docking/make_plots.py
+++ b/src/plinder-eval/plinder/eval/docking/make_plots.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from dataclasses import dataclass
 from pathlib import Path
 

--- a/src/plinder-eval/plinder/eval/docking/stratify_test_set.py
+++ b/src/plinder-eval/plinder/eval/docking/stratify_test_set.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 import multiprocessing

--- a/src/plinder-eval/plinder/eval/docking/utils.py
+++ b/src/plinder-eval/plinder/eval/docking/utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
 from collections import defaultdict

--- a/src/plinder-eval/plinder/eval/docking/write_scores.py
+++ b/src/plinder-eval/plinder/eval/docking/write_scores.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 import json
 import multiprocessing
 from collections import defaultdict

--- a/src/plinder-methods/plinder/methods/__init__.py
+++ b/src/plinder-methods/plinder/methods/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from pathlib import Path
 from io import StringIO
 

--- a/tests/core/test_core_config.py
+++ b/tests/core/test_core_config.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from json import dumps
 from hashlib import md5
 from dataclasses import asdict

--- a/tests/core/test_core_scores.py
+++ b/tests/core/test_core_scores.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 import pytest
 
 from plinder.core import scores

--- a/tests/core/test_gcs.py
+++ b/tests/core/test_gcs.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 import os
 
 import pytest

--- a/tests/core/test_plinder_core.py
+++ b/tests/core/test_plinder_core.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 import pytest
 
 try:

--- a/tests/data/pipeline/test_config.py
+++ b/tests/data/pipeline/test_config.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 import sys
 import unittest.mock
 from textwrap import dedent

--- a/tests/data/pipeline/test_io.py
+++ b/tests/data/pipeline/test_io.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from plinder.data.pipeline import io
 
 import pandas as pd

--- a/tests/data/pipeline/test_pipeline.py
+++ b/tests/data/pipeline/test_pipeline.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 
 from plinder.data.pipeline import config, pipeline
 

--- a/tests/data/pipeline/test_tasks.py
+++ b/tests/data/pipeline/test_tasks.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from plinder.data.pipeline import tasks
 from plinder.data.pipeline import io
 

--- a/tests/data/pipeline/test_transform.py
+++ b/tests/data/pipeline/test_transform.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from plinder.data.pipeline import transform
 
 import pytest

--- a/tests/data/pipeline/test_utils.py
+++ b/tests/data/pipeline/test_utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 import pytest
 
 from plinder.data.pipeline import utils

--- a/tests/data/test_plinder_data.py
+++ b/tests/data/test_plinder_data.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 def test_ost():
     try:
         import openstructure as ost

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 import shutil
 import requests
 from io import StringIO

--- a/tests/test_atoms.py
+++ b/tests/test_atoms.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from biotite.structure import AtomArray
 from rdkit import Chem
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 from plinder.eval.docking import utils
 import numpy as np
 

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 
 def test_get_smiles_dict(mock_alternative_datasets):
     entry_dir = mock_alternative_datasets("test")

--- a/tests/test_final_structure_checks.py
+++ b/tests/test_final_structure_checks.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 import pandas as pd
 from plinder.data.final_structure_qc import run_all_checks
 

--- a/tests/test_rdkit_utils.py
+++ b/tests/test_rdkit_utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 
 def test_valence_issue_handling():
     from rdkit import Chem

--- a/tests/test_smallmolecules.py
+++ b/tests/test_smallmolecules.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
 import numpy as np
 
 from plinder.data.smallmolecules import (


### PR DESCRIPTION
This PR adds license copy to the top of all `.py` files in the repository and addresses vulnerabilities identified by dependabot, good bot. It additionally ports CI utilities to use the GitHub container registry for docker image persistence.