### PR TITLE
Crystal lattice contact counter

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -99,7 +99,7 @@ preferred-citation:
     given-names: "Luca"
   doi: "10.1101/2024.07.17.603955"
   journal: "bioRxiv"
-  eventtitle: "Machine Learning for Life and Material Science, ICML 2024",
+  eventtitle: "Machine Learning for Life and Material Science, ICML 2024"
   month: 7
   title: "PLINDER: The Protein-Ligand Interactions Dataset and Evaluation Resource"
   year: 2024

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -99,7 +99,7 @@ preferred-citation:
     given-names: "Luca"
   doi: "10.1101/2024.07.17.603955"
   journal: "bioRxiv"
-  eventtitle: "Machine Learning for Life and Material Science, ICML 2024"
+  eventtitle: "Machine Learning for Life and Material Science, ICML 2024",
   month: 7
   title: "PLINDER: The Protein-Ligand Interactions Dataset and Evaluation Resource"
   year: 2024

--- a/README.md
+++ b/README.md
@@ -115,17 +115,22 @@ Finally, a particular care is taken for test set that is further prioritized to 
 
 Moreover, as we enticipate this resource to be used for benchmarking a wide range of methods, including those simultaneously predicting protein structure (aka. co-folding) or those generating novel ligand structures, we further stratified test (by novel ligand, pocket, protein or all) to cover a wide range of tasks.
 
-Our latest test split contains:
+Our latest test split [#TODO] contains:
 
-| Novel   |   # of systems | # of high quality |  stratification criteria |
+| Novel   |   # of systems | # of high quality |  stratification criteria | 
 |:--------|---------------:|------------------:|:---------------:|
-| pocket  | 5206 | 5203 | PLI shared < 50 _&_  Pocket shared lDDT < 0.5 |
-| ligand  | 2395 | 2395 | ECFP4 fingerprint similarity < 0.3 |
-| protein |  983 |  983 | Protein Seq. Sim. < 0.3 _&_ Protein lDDT > 0.7 |
-| all     |  268 |  268 | all of the above |
+| pocket  | 5152 | 5149 | PLI shared < 50 _&_  Pocket shared lDDT < 0.5 |
+| ligand  | 2375 | 2375 | ECFP4 fingerprint similarity < 0.3 |
+| protein |  960 |  960 | Protein Seq. Sim. < 0.3 _&_ Protein lDDT > 0.7 |
+| all     |  249 |  249 | all of the above |
 | none    |    0 |    0 | none of the above |
 
-## ⚖️ Evaluation harness
+
+## 🧪 Training set
+
+Discuss the splits
+
+## ⚖️  Evaluation harness
 
 See the [`plinder.eval`](#src/plinder-eval/plinder/eval/docking/README.md) docs for more details.
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ since the previous release:
 **NOTE**: The CI workflow will use the __most recent__ match in the commit history to make its decision.
 
 # 📃 Publications
-Durairaj, Janani, Yusuf Adeshina, Zhonglin Cao, Xuejin Zhang, Vladas Oleinikovas, Thomas Duignan, Zachary McClure, Xavier Robin, Emanuele Rossi, Guoqing Zhou, Srimukh Prasad Veccham, Clemens Isert, Yuxing Peng, Prabindh Sundareson, Mehmet Akdel, Gabriele Corso, Hannes Stärk, Zachary Wayne Carpenter, Michael M. Bronstein, Emine Kucukbenli, Torsten Schwede, Luca Naef. 2024. “PLINDER: The Protein-Ligand Interactions Dataset and Evaluation Resource.” 
+Durairaj, Janani, Yusuf Adeshina, Zhonglin Cao, Xuejin Zhang, Vladas Oleinikovas, Thomas Duignan, Zachary McClure, Xavier Robin, Emanuele Rossi, Guoqing Zhou, Srimukh Prasad Veccham, Clemens Isert, Yuxing Peng, Prabindh Sundareson, Mehmet Akdel, Gabriele Corso, Hannes Stärk, Zachary Wayne Carpenter, Michael M. Bronstein, Emine Kucukbenli, Torsten Schwede, Luca Naef. 2024. “PLINDER: The Protein-Ligand Interactions Dataset and Evaluation Resource.”
 
 [bioRxiv](https://doi.org/10.1101/2024.07.17.603955)
 [ICML'24 ML4LMS](https://openreview.net/forum?id=7UvbaTrNbP)

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Moreover, as we enticipate this resource to be used for benchmarking a wide rang
 
 Our latest test split [#TODO] contains:
 
-| Novel   |   # of systems | # of high quality |  stratification criteria | 
+| Novel   |   # of systems | # of high quality |  stratification criteria |
 |:--------|---------------:|------------------:|:---------------:|
 | pocket  | 5206 | 5203 | PLI shared < 50 _&_  Pocket shared lDDT < 0.5 |
 | ligand  | 2395 | 2395 | ECFP4 fingerprint similarity < 0.3 |

--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ Our latest test split [#TODO] contains:
 
 | Novel   |   # of systems | # of high quality |  stratification criteria | 
 |:--------|---------------:|------------------:|:---------------:|
-| pocket  | 5152 | 5149 | PLI shared < 50 _&_  Pocket shared lDDT < 0.5 |
-| ligand  | 2375 | 2375 | ECFP4 fingerprint similarity < 0.3 |
-| protein |  960 |  960 | Protein Seq. Sim. < 0.3 _&_ Protein lDDT > 0.7 |
-| all     |  249 |  249 | all of the above |
+| pocket  | 5206 | 5203 | PLI shared < 50 _&_  Pocket shared lDDT < 0.5 |
+| ligand  | 2395 | 2395 | ECFP4 fingerprint similarity < 0.3 |
+| protein |  983 |  983 | Protein Seq. Sim. < 0.3 _&_ Protein lDDT > 0.7 |
+| all     |  268 |  268 | all of the above |
 | none    |    0 |    0 | none of the above |
 
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ since the previous release:
 **NOTE**: The CI workflow will use the __most recent__ match in the commit history to make its decision.
 
 # 📃 Publications
-Durairaj, Janani, Yusuf Adeshina, Zhonglin Cao, Xuejin Zhang, Vladas Oleinikovas, Thomas Duignan, Zachary McClure, Xavier Robin, Emanuele Rossi, Guoqing Zhou, Srimukh Prasad Veccham, Clemens Isert, Yuxing Peng, Prabindh Sundareson, Mehmet Akdel, Gabriele Corso, Hannes Stärk, Zachary Wayne Carpenter, Michael M. Bronstein, Emine Kucukbenli, Torsten Schwede, Luca Naef. 2024. “PLINDER: The Protein-Ligand Interactions Dataset and Evaluation Resource.”
+Durairaj, Janani, Yusuf Adeshina, Zhonglin Cao, Xuejin Zhang, Vladas Oleinikovas, Thomas Duignan, Zachary McClure, Xavier Robin, Emanuele Rossi, Guoqing Zhou, Srimukh Prasad Veccham, Clemens Isert, Yuxing Peng, Prabindh Sundareson, Mehmet Akdel, Gabriele Corso, Hannes Stärk, Zachary Wayne Carpenter, Michael M. Bronstein, Emine Kucukbenli, Torsten Schwede, Luca Naef. 2024. “PLINDER: The Protein-Ligand Interactions Dataset and Evaluation Resource.” 
+
 [bioRxiv](https://doi.org/10.1101/2024.07.17.603955)
 [ICML'24 ML4LMS](https://openreview.net/forum?id=7UvbaTrNbP)

--- a/src/plinder/data/utils/annotations/lattice_contacts.py
+++ b/src/plinder/data/utils/annotations/lattice_contacts.py
@@ -6,9 +6,9 @@ import multiprocessing
 import os
 import re
 import subprocess
-import pandas as pd
 from pathlib import Path
-from typing import Tuple
+
+import pandas as pd
 
 from plinder.core.utils.log import setup_logger
 

--- a/src/plinder/data/utils/annotations/lattice_contacts.py
+++ b/src/plinder/data/utils/annotations/lattice_contacts.py
@@ -2,140 +2,207 @@
 # Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
-import sys
+import multiprocessing
+import os
+import re
+import subprocess
+import pandas as pd
 from pathlib import Path
+from typing import Tuple
 
-import numpy as np
+from plinder.core.utils.log import setup_logger
 
+LOG = setup_logger(__name__)
 
-def fetch_pdb(pdb_id: str) -> None:
-    cmd.fetch(pdb_id)
-    # Takes care of edge cases where the whole protein has been modelled
-    # as an alt loc.
-    # select alt locs
-    cmd.select("nonalts", f"{pdb_id} and poly and alt ''+'A'")
-    if len(cmd.get_model("nonalts").get_residues()) == 0:
-        cmd.alter(pdb_id, "alt=''")
-
-
-def get_pairwise_distances(xyz1, xyz2):
-    """
-    Get fast pairwise Euclidean distances between coordinates.
-    xyz1, xyz2 : numpy arrays of shapes (N, 3) and (M, 3)
-    The result is a numpy matrix array (N, M).
-    """
-    A2 = np.broadcast_to([np.dot(r, r.T) for r in xyz1], (len(xyz2), len(xyz1))).T
-    AB = np.dot(xyz1, xyz2.T).astype("float")
-    B2 = np.broadcast_to([np.dot(r, r.T) for r in xyz2], (len(xyz1), len(xyz2)))
-    return np.sqrt(A2 - 2 * AB + B2)
+# Need to have pymol env installed
+# works with Python 3.8.13 (datascience-1.0__1 environment)
+pymol_install_instructions = """
+# NOTE: this might need sudo permissions
+apt-get update
+apt install -y libgl1-mesa-glx
+bash
+conda create -n pymol -c schrodinger pymol-bundle -y
+conda activate pymol
+# test import
+python -c 'import pymol'
+"""
+PYMOL_PYTHON = os.environ["CONDA_EXE"].split("bin")[0] + "envs/pymol/bin/python"
+SCRIPT_NAME = "pymol_lattice_contacts_script.py"
+NEWLINE = "\n"
 
 
-def get_pymol_coordinates(selection: str) -> list[list[float, float, float]]:
-    # set dictionary to store variables
-    pymolspace = {}
-    pymolspace["xyz"] = []
-    cmd.iterate_state(1, selection, "xyz.append([x, y, z])", space=pymolspace)
-    return pymolspace["xyz"]
-
-
-def get_cog(selection: str, ca_only: bool = True) -> tuple[float, float, float]:
-    if ca_only:
-        selection = f"(({selection}) and name CA)"
-    xyz = get_pymol_coordinates(selection)
-    return np.mean(xyz, axis=1)
-
-
-def get_symmetry_contact_number(
-    system_id: Path | str,
-    ligand_sdf: Path | str,
-    receptor_cif: Path | str,
+def pymol_lattice_contacts_process(
+    system_id: str,
+    ligand_sdf: Path,
+    receptor_cif: Path,
+    output_file: Path,
     cutoff: float = 4,
-) -> int:
-    # load original pdb entry
-    pdb_id = system_id.split("/")[-1].split("_")[0]
-    fetch_pdb(pdb_id)
+) -> None:
+    # run through a subprocess to avoid memory problems with PyMOL.
+    proc = subprocess.Popen(
+        f"{PYMOL_PYTHON} -u {SCRIPT_NAME} {system_id} {ligand_sdf} {receptor_cif} {output_file} {cutoff}",
+        shell=True,
+        stderr=subprocess.PIPE,
+    )
+    if proc.stderr:
+        stderr = proc.stderr.read().decode()
+    # check if everything went ok with the processing
+    if bool(re.search("ImportError", stderr)):
+        raise ImportError(
+            f"""Check if PYMOL_PYTHON={PYMOL_PYTHON} is correctly installed: {stderr}"""
+        )
+    elif bool(re.search("Error", stderr)):
+        raise ValueError(f"Processing error occured:{NEWLINE}{stderr}")
 
-    # load ligand
-    cmd.load(ligand_sdf, "ligand")
 
-    # generate symmetry mates around the ligand
-    cmd.symexp("symexp*", pdb_id, "ligand", cutoff=cutoff, segi=1)
-    symmetry_mates = cmd.get_object_list("symexp*")
+def run_system_lattice_contacts(
+    system_id: str,
+    data_dir: Path,
+    output_dir: Path,
+    cutoff: float = 4,
+    overwrite: bool = False,
+) -> None:
+    pdb_id = system_id.split("_")[0]
+    system_dir = data_dir / "systems" / pdb_id[-3:-1] / system_id
+    receptor_cif = system_dir / "receptor.cif"
+    ligand_dir = system_dir / "ligand_files"
+    for lig_sdf in ligand_dir.glob("*.sdf"):
+        contact_filename = f"{system_id}_{lig_sdf.name.split('.sdf')[0]}_{cutoff}.csv"
+        output_file = output_dir / "lattice_contacts_tmp" / contact_filename
+        if overwrite or not output_file.exists():
+            try:
+                # run the pymol process for one system
+                pymol_lattice_contacts_process(
+                    system_id, lig_sdf, receptor_cif, output_file, cutoff=cutoff
+                )
+                if not output_file.exists():
+                    raise ValueError(f"Cannot find output {output_file}")
+            except Exception as e:
+                LOG.info(f"Error running pymol process for {system_id}:{NEWLINE}{e}")
 
-    # contact count
-    crystal_contacts = 0
 
-    if len(symmetry_mates):
-        # detect and remove symmetry mates that overlap with receptor
-        # eg. receptor incorporates more than assymetric unit to complete biounit
-        cmd.load(receptor_cif, "receptor")
+def get_lattice_contacts_annotations(
+    df: pd.DataFrame,
+    data_dir: Path,
+    output_dir: Path,
+    cutoff: float,
+) -> pd.DataFrame:
+    num_cont_lig_list = []
+    num_cont_symm_list = []
+    for system_id in df["system_id"]:
+        sys_num_cont_lig = 0
+        sys_num_cont_symm = 0
+        for output_file in output_dir.glob(
+            f"lattice_contacts_tmp/{system_id}_*_{cutoff}.csv"
+        ):
+            # NOTE: for multi ligand systems, we sum up the number of contacts
+            num_cont_lig, num_cont_symm = pd.read_csv(
+                output_file, names=["num_cont_lig", "num_cont_symm"]
+            ).values[0]
+            sys_num_cont_lig += num_cont_lig
+            sys_num_cont_symm += num_cont_symm
+        num_cont_lig_list.append(sys_num_cont_lig)
+        num_cont_symm_list.append(sys_num_cont_symm)
+    df["num_cont_lig"] = num_cont_lig_list
+    df["num_cont_symm"] = num_cont_symm_list
+    return df
 
-        # before getting coords - remove any ambiguous atoms and hydrogens
-        cmd.remove("name *?")
-        cmd.remove("e. h")
 
-        cog_rec = get_cog("receptor", ca_only=True)
-        xyz_lig = get_pymol_coordinates("ligand")
+def run_annotations_for_split(
+    split_file: Path,
+    data_dir: Path,
+    output_dir: Path,
+    cutoff: float = 4,
+    test_label: str = "test",
+    num_processes: int = 8,
+    overwrite: bool = False,
+) -> None:
+    if split_file.name.endswith(".csv"):
+        df = pd.read_csv(split_file)
+    else:
+        df = pd.read_parquet(split_file)
+    assert all(x in df.columns for x in ["split", "system_id"])
 
-        for symmate in symmetry_mates:
-            # get distance between CoG of CAs and compare if within tolerance
-            cog_mate = get_cog(symmate, ca_only=True)
-            # given some buffer for numerical error
-            if np.linalg.norm(cog_mate - cog_rec) > 0.1:
-                # this is a real symmetry mate that is not part of biounit
-                xyz = get_pymol_coordinates(symmate)
-                pair_dists = get_pairwise_distances(xyz_lig, xyz)
-                print(np.shape(xyz_lig))
-                print(np.shape(pair_dists))
-                print(np.shape(np.min(pair_dists, axis=0)))
-                # crystal_contacts as number of symmetry mate atoms within cutoff
-                contact_num = np.sum(np.min(pair_dists, axis=0) < cutoff)
-                crystal_contacts += contact_num
-    return crystal_contacts
+    output_dir.mkdir(exist_ok=True)
+    # adding a place to write intermediate files
+    output_tmp_dir = output_dir / "lattice_contacts_tmp"
+    output_tmp_dir.mkdir(exist_ok=True)
+    # run the pymol process for all test systems
+    df = df[df["split"] == test_label].copy()
+
+    multiprocessing.set_start_method("spawn")
+    with multiprocessing.Pool(num_processes) as p:
+        p.starmap(
+            run_system_lattice_contacts,
+            [
+                (system_id, data_dir, output_dir, cutoff, overwrite)
+                for system_id in df.system_id
+            ],
+        )
+
+    df = get_lattice_contacts_annotations(df, data_dir, output_dir, cutoff)
+    df.to_parquet(output_dir / f"lattice_contacts_{test_label}.parquet")
 
 
 def main() -> None:
-    # f"{PYMOL_PYTHON} -u lattice_contacts.py {system_id} {ligand_path} {receptor_path} {cutoff}"
+    import argparse
 
-    # use command line
-    # Importing the PyMOL module will create the window.
-    import pymol
-
-    # Tell PyMOL we don't want any GUI features.
-    pymol.pymol_argv = ["pymol", "-Qic"]
-    # Call the function below before using any PyMOL modules.
-    pymol.finish_launching()
-
-    # import argparse
-    # parser = argparse.ArgumentParser(description="Annotate and stratify a test set")
-    # parser.add_argument(
-    #     "--split_file",
-    #     type=Path,
-    #     help="Path to split file with [system_id, split] as columns",
-    # )
-    # parser.add_argument(
-    #     "--data_dir",
-    #     type=Path,
-    #     help="Path to plinder data",
-    # )
-    # parser.add_argument(
-    #     "--output_dir",
-    #     type=Path,
-    #     help="Path to output folder where similarity and stratification data are saved",
-    # )
-
-    # assign command line arguments
-    system_id = sys.argv[1]
-    ligand_sdf = sys.argv[2]
-    receptor_cif = sys.argv[3]
-    cutoff = int(sys.argv[4])
-
-    # run the main code
-    res = get_symmetry_contact_number(
-        system_id, ligand_sdf, receptor_cif, cutoff=cutoff
+    parser = argparse.ArgumentParser(
+        description="Annotate test set for lattice contacts"
     )
-    print(res)
+    parser.add_argument(
+        "--split_file",
+        type=Path,
+        help="Path to split file with [system_id, split] as columns",
+    )
+    parser.add_argument(
+        "--data_dir",
+        type=Path,
+        help="Path to plinder data",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=Path,
+        help="Path to output folder where lattice contact data are saved",
+    )
+    parser.add_argument(
+        "--cutoff",
+        type=float,
+        default=4.0,
+        help="Cutoff for lattice contacts",
+    )
+    parser.add_argument(
+        "--test_label",
+        type=str,
+        default="test",
+        help="split=<test_label> is used to get test systems",
+    )
+    parser.add_argument(
+        "--num_processes",
+        type=int,
+        default=8,
+        help="Number of processes to use",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite crystal contacts files",
+    )
 
+    args = parser.parse_args()
+
+    run_annotations_for_split(
+        split_file=args.split_file,
+        data_dir=args.data_dir,
+        output_dir=args.output_dir,
+        cutoff=args.cutoff,
+        test_label=args.test_label,
+        num_processes=args.num_processes,
+        overwrite=args.overwrite,
+    )
+
+
+# python lattice_contacts.py --split_file split.csv --data_dir ~/plinder_local_data/v2/ --output_dir .
 
 if __name__ == "__main__":
     main()

--- a/src/plinder/data/utils/annotations/lattice_contacts.py
+++ b/src/plinder/data/utils/annotations/lattice_contacts.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+def fetch_pdb(pdb_id: str) -> None:
+    cmd.fetch(pdb_id)
+    # Takes care of edge cases where the whole protein has been modelled
+    # as an alt loc.
+    # select alt locs
+    cmd.select("nonalts", f"{pdb_id} and poly and alt ''+'A'")
+    if len(cmd.get_model("nonalts").get_residues()) == 0:
+        cmd.alter(pdb_id, "alt=''")
+
+
+def get_pairwise_distances(xyz1, xyz2):
+    """
+    Get fast pairwise Euclidean distances between coordinates.
+    xyz1, xyz2 : numpy arrays of shapes (N, 3) and (M, 3)
+    The result is a numpy matrix array (N, M).
+    """
+    A2 = np.broadcast_to([np.dot(r, r.T) for r in xyz1], (len(xyz2), len(xyz1))).T
+    AB = np.dot(xyz1, xyz2.T).astype("float")
+    B2 = np.broadcast_to([np.dot(r, r.T) for r in xyz2], (len(xyz1), len(xyz2)))
+    return np.sqrt(A2 - 2 * AB + B2)
+
+
+def get_pymol_coordinates(selection: str) -> list[list[float, float, float]]:
+    # set dictionary to store variables
+    pymolspace = {}
+    pymolspace["xyz"] = []
+    cmd.iterate_state(1, selection, "xyz.append([x, y, z])", space=pymolspace)
+    return pymolspace["xyz"]
+
+
+def get_cog(selection: str, ca_only: bool = True) -> tuple[float, float, float]:
+    if ca_only:
+        selection = f"(({selection}) and name CA)"
+    xyz = get_pymol_coordinates(selection)
+    return np.mean(xyz, axis=1)
+
+
+def get_symmetry_contact_number(
+    system_id: Path | str,
+    ligand_sdf: Path | str,
+    receptor_cif: Path | str,
+    cutoff: float = 4,
+) -> int:
+    # load original pdb entry
+    pdb_id = system_id.split("/")[-1].split("_")[0]
+    fetch_pdb(pdb_id)
+
+    # load ligand
+    cmd.load(ligand_sdf, "ligand")
+
+    # generate symmetry mates around the ligand
+    cmd.symexp("symexp*", pdb_id, "ligand", cutoff=cutoff, segi=1)
+    symmetry_mates = cmd.get_object_list("symexp*")
+
+    # contact count
+    crystal_contacts = 0
+
+    if len(symmetry_mates):
+        # detect and remove symmetry mates that overlap with receptor
+        # eg. receptor incorporates more than assymetric unit to complete biounit
+        cmd.load(receptor_cif, "receptor")
+
+        # before getting coords - remove any ambiguous atoms and hydrogens
+        cmd.remove("name *?")
+        cmd.remove("e. h")
+
+        cog_rec = get_cog("receptor", ca_only=True)
+        xyz_lig = get_pymol_coordinates("ligand")
+
+        for symmate in symmetry_mates:
+            # get distance between CoG of CAs and compare if within tolerance
+            cog_mate = get_cog(symmate, ca_only=True)
+            # given some buffer for numerical error
+            if np.linalg.norm(cog_mate - cog_rec) > 0.1:
+                # this is a real symmetry mate that is not part of biounit
+                xyz = get_pymol_coordinates(symmate)
+                pair_dists = get_pairwise_distances(xyz_lig, xyz)
+                print(np.shape(xyz_lig))
+                print(np.shape(pair_dists))
+                print(np.shape(np.min(pair_dists, axis=0)))
+                # crystal_contacts as number of symmetry mate atoms within cutoff
+                contact_num = np.sum(np.min(pair_dists, axis=0) < cutoff)
+                crystal_contacts += contact_num
+    return crystal_contacts
+
+
+def main() -> None:
+    # f"{PYMOL_PYTHON} -u lattice_contacts.py {system_id} {ligand_path} {receptor_path} {cutoff}"
+
+    # use command line
+    # Importing the PyMOL module will create the window.
+    import pymol
+
+    # Tell PyMOL we don't want any GUI features.
+    pymol.pymol_argv = ["pymol", "-Qic"]
+    # Call the function below before using any PyMOL modules.
+    pymol.finish_launching()
+
+    # import argparse
+    # parser = argparse.ArgumentParser(description="Annotate and stratify a test set")
+    # parser.add_argument(
+    #     "--split_file",
+    #     type=Path,
+    #     help="Path to split file with [system_id, split] as columns",
+    # )
+    # parser.add_argument(
+    #     "--data_dir",
+    #     type=Path,
+    #     help="Path to plinder data",
+    # )
+    # parser.add_argument(
+    #     "--output_dir",
+    #     type=Path,
+    #     help="Path to output folder where similarity and stratification data are saved",
+    # )
+
+    # assign command line arguments
+    system_id = sys.argv[1]
+    ligand_sdf = sys.argv[2]
+    receptor_cif = sys.argv[3]
+    cutoff = int(sys.argv[4])
+
+    # run the main code
+    res = get_symmetry_contact_number(
+        system_id, ligand_sdf, receptor_cif, cutoff=cutoff
+    )
+    print(res)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/plinder/data/utils/annotations/pymol_lattice_contacts_script.py
+++ b/src/plinder/data/utils/annotations/pymol_lattice_contacts_script.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import List, Tuple, Dict, Any
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 from numpy.typing import NDArray

--- a/src/plinder/data/utils/annotations/pymol_lattice_contacts_script.py
+++ b/src/plinder/data/utils/annotations/pymol_lattice_contacts_script.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2024, Plinder Development Team
+# Distributed under the terms of the Apache License 2.0
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Tuple, Dict, Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def fetch_pdb(pdb_id: str) -> None:
+    # TODO: cmd.load(mmcif_file) - get from nextgen source
+    cmd.fetch(pdb_id)
+    # Takes care of edge cases where the whole protein has been modelled
+    # as an alt loc.
+    # select alt locs
+    cmd.select("nonalts", f"{pdb_id} and poly and alt ''+'A'")
+    if len(cmd.get_model("nonalts").get_residues()) == 0:
+        cmd.alter(pdb_id, "alt=''")
+
+
+def get_pairwise_distances(
+    xyz1: NDArray[np.float64], xyz2: NDArray[np.float64]
+) -> NDArray[np.float64]:
+    """
+    Get fast pairwise Euclidean distances between coordinates.
+    xyz1, xyz2 : numpy arrays of shapes (N, 3) and (M, 3)
+    The result is a numpy matrix array (N, M).
+    """
+    A2 = np.broadcast_to([np.dot(r, r.T) for r in xyz1], (len(xyz2), len(xyz1))).T
+    AB = np.dot(xyz1, xyz2.T).astype("float")
+    B2 = np.broadcast_to([np.dot(r, r.T) for r in xyz2], (len(xyz1), len(xyz2)))
+    return np.sqrt(A2 - 2 * AB + B2)
+
+
+def get_pymol_coordinates(selection: str) -> NDArray[Any]:
+    # set dictionary to store variables
+    pymolspace: Dict[str, List[Any]] = {}
+    pymolspace["xyz"] = []
+    cmd.iterate_state(1, selection, "xyz.append([x, y, z])", space=pymolspace)
+    return np.array(pymolspace["xyz"])
+
+
+def get_cog(selection: str, ca_only: bool = True) -> NDArray[np.float64]:
+    if ca_only:
+        selection = f"(({selection}) and name CA)"
+    xyz = get_pymol_coordinates(selection)
+    return np.mean(xyz, axis=1)
+
+
+def get_symmetry_contact_number(
+    system_id: str,
+    ligand_sdf: Path | str,
+    receptor_cif: Path | str,
+    cutoff: float = 4,
+) -> Tuple[int, int]:
+    # load original pdb entry
+    pdb_id = system_id.split("_")[0]
+    fetch_pdb(pdb_id)
+
+    # load ligand
+    cmd.load(ligand_sdf, "ligand")
+
+    # generate symmetry mates around the ligand
+    cmd.symexp("symexp*", pdb_id, "ligand", cutoff=cutoff, segi=1)
+    symmetry_mates = cmd.get_object_list("symexp*")
+    # TODO: test for cases when symmetry mates are not & polymer
+
+    # contact count
+    num_symmetry_mates_contacts = 0
+    num_lig_contacts = 0
+
+    if len(symmetry_mates):
+        # detect and remove symmetry mates that overlap with receptor
+        # eg. receptor incorporates more than assymetric unit to complete biounit
+        cmd.load(receptor_cif, "receptor")
+
+        # before getting coords - remove any ambiguous atoms and hydrogens
+        cmd.remove("name *?")
+        cmd.remove("e. h")
+
+        cog_rec = get_cog("receptor", ca_only=True)
+        xyz_lig = get_pymol_coordinates("ligand")
+        # store ligand atom contacts as array in case of multiple symmetry mates in contact
+        lig_atoms_in_crystal_contact = np.zeros(len(xyz_lig))
+
+        for symmate in symmetry_mates:
+            # get distance between CoG of CAs and compare if within tolerance
+            cog_mate = get_cog(f"({symmate} & polymer)", ca_only=True)
+            # given some buffer for numerical error
+            if np.linalg.norm(cog_mate - cog_rec) > 0.1:
+                # this is a real symmetry mate that is not part of biounit
+                xyz = get_pymol_coordinates(symmate)
+                pair_contacts = get_pairwise_distances(xyz_lig, xyz) < cutoff
+                lig_atoms_in_crystal_contact += np.max(pair_contacts, axis=1)
+                # print(lig_atoms_in_crystal_contact)
+                # print(np.shape(pair_contacts))
+                # crystal_contacts as number of symmetry mate atoms within cutoff
+                num_symmetry_mates_contacts += np.sum(np.max(pair_contacts, axis=0))
+        # count each ligand atom only once!
+        num_lig_contacts = np.sum(lig_atoms_in_crystal_contact > 0)
+        # TODO: test for multiple symmetry mates in contact
+        # print(num_lig_contacts, num_symmetry_mates_contacts)
+    return num_lig_contacts, num_symmetry_mates_contacts
+
+
+def main() -> None:
+    # assign command line arguments
+    system_id = sys.argv[1]
+    ligand_sdf = sys.argv[2]
+    receptor_cif = sys.argv[3]
+    output_file = sys.argv[4]
+    cutoff = float(sys.argv[5])
+
+    # run the main code
+    num_cont_lig, num_cont_symm = get_symmetry_contact_number(
+        system_id, ligand_sdf, receptor_cif, cutoff=cutoff
+    )
+    # print(num_cont_lig, num_cont_symm)
+    # print(','.join([str(num_cont_lig), str(num_cont_symm)]))
+    with open(output_file, "w") as out:
+        out.write(",".join([str(num_cont_lig), str(num_cont_symm)]))
+
+
+if __name__ == "__main__":
+    # use command line
+    # f"{PYMOL_PYTHON} -u pymol_lattice_contacts_script.py {system_id} {ligand_path} {receptor_path} {output_file} {cutoff}"
+    # python pymol_lattice_contacts_script.py 1az2__1__1.A__1.B_1.C ~/plinder_local_data/v2/az/1az2__1__1.A__1.B_1.C/ligand_files/1.B.sdf ~/plinder_local_data/v2/az/1az2__1__1.A__1.B_1.C/receptor.cif out.csv 6
+
+    import pymol
+    import pymol.cmd as cmd
+
+    # Importing the PyMOL module will create the window.
+    # Tell PyMOL we don't want any GUI features.
+    pymol.pymol_argv = ["pymol", "-Qic"]
+    # Call the function below before using any PyMOL modules.
+    pymol.finish_launching()
+    main()


### PR DESCRIPTION
Used PyMOL to detect lattice contacts that are within a cutoff to a ligand.

Currently, this requires installing a separate pymol environment.

Multiprocessed script that takes test split data and estimates the contacts for a given ligand system: detect for both total number of contacts from lattice to ligand, and total number of ligand atoms involved in the contacts.

Ideally, this should be done at the earlier stage of annotation, but currently may be too slow to run for the entire dataset.

Update: rebased onto main.