### PR TITLE
feat: change system and interaction definition

### DIFF
--- a/src/plinder/data/utils/annotations/aggregate_annotations.py
+++ b/src/plinder/data/utils/annotations/aggregate_annotations.py
@@ -213,6 +213,8 @@ class System(BaseModel):
             lambda: defaultdict(list)
         )
         for ligand in self.ligands:
+            if ligand.is_artifact:
+                continue
             for chain in ligand.interactions:
                 for residue in ligand.interactions[chain]:
                     all_interactions[chain][residue].extend(

--- a/src/plinder/data/utils/annotations/ligand_utils.py
+++ b/src/plinder/data/utils/annotations/ligand_utils.py
@@ -1130,9 +1130,8 @@ class Ligand(BaseModel):
 
     @cached_property
     def interacting_protein_chains(self) -> list[str]:
-        interacting_chains = list(sorted(self.interacting_residues.keys()))
-        if len(interacting_chains):
-            return interacting_chains
+        if self.is_artifact:
+            return []
         else:
             return self.neighboring_protein_chains
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -330,7 +330,7 @@ def test_simple_ternary_detection(cif_2p1q, mock_alternative_datasets):
     plinder_anno = GetPlinderAnnotation(cif_2p1q, "", save_folder=entry_dir)
     plinder_anno.annotate()
     df = plinder_anno.annotated_df
-    assert sorted(set(df.ligand_ccd_code.to_list())) == ["IAC", "IHP"]
+    assert sorted(set(df.ligand_ccd_code.to_list())) == ["IAC"]
     auxin_entry = df.ligand_ccd_code == "IAC"
     # expect two chains to get this correct!
     assert df[auxin_entry][


### PR DESCRIPTION
Change system definition to not rely on PLIP - (1) systems are defined by neighboring_protein_chains, and (2) artifacts are always set to have no interactions and hence not saved unless part of a holo or ion system.