### PR TITLE
Fix pred linked structure generation

### DIFF
--- a/flows/data_ingest.py
+++ b/flows/data_ingest.py
@@ -12,7 +12,7 @@ from metaflow import FlowSpec, Parameter, kubernetes, environment, step, retry
 MOUNT = "/plinder"
 K8S = dict(
     cpu=1,
-    image="us-east1-docker.pkg.dev/vantai-analysis/metaflow/plinder:v0.1.3-50-g95faf3ec-dirty",
+    image="us-east1-docker.pkg.dev/vantai-analysis/metaflow/plinder:v0.1.4-1-geab6e359",
     node_selector={
         "topology.kubernetes.io/zone": "us-east1-b",
     },

--- a/flows/data_ingest.py
+++ b/flows/data_ingest.py
@@ -12,7 +12,7 @@ from metaflow import FlowSpec, Parameter, kubernetes, environment, step, retry
 MOUNT = "/plinder"
 K8S = dict(
     cpu=1,
-    image="us-east1-docker.pkg.dev/vantai-analysis/metaflow/plinder:v0.1.4-1-geab6e359",
+    image="us-east1-docker.pkg.dev/vantai-analysis/metaflow/plinder:v0.1.4-2-ge3663ef5",
     node_selector={
         "topology.kubernetes.io/zone": "us-east1-b",
     },

--- a/src/plinder/core/__init__.py
+++ b/src/plinder/core/__init__.py
@@ -1,15 +1,32 @@
 # Copyright (c) 2024, Plinder Development Team
 # Distributed under the terms of the Apache License 2.0
-
 from pathlib import Path
+from textwrap import dedent
 
 _root = Path(__file__).parent.parent
 
 from plinder.core.index.utils import get_manifest, get_plindex
-from plinder.core.loader.loader import PlinderDataset
 from plinder.core.split.utils import get_split
 from plinder.core.system.system import PlinderSystem
 from plinder.core.utils.config import get_config
+
+try:
+    from plinder.core.loader.loader import PlinderDataset
+except (ImportError, ModuleNotFoundError):
+    print(
+        dedent(
+            """\
+            plinder.core.PlinderDataset requires pytorch and atom3d.
+
+            please run:
+
+                pip install plinder[loader]
+
+            to enable the data loader
+            """
+        )
+    )
+    PlinderDataset = None
 
 __all__ = [
     "get_config",

--- a/src/plinder/core/__init__.py
+++ b/src/plinder/core/__init__.py
@@ -9,6 +9,7 @@ from plinder.core.index.utils import get_manifest, get_plindex
 from plinder.core.split.utils import get_split
 from plinder.core.system.system import PlinderSystem
 from plinder.core.utils.config import get_config
+from plinder.core.loader.loader import PlinderDataset
 
 __all__ = [
     "get_config",
@@ -16,4 +17,5 @@ __all__ = [
     "get_manifest",
     "get_split",
     "PlinderSystem",
+    "PlinderDataset",
 ]

--- a/src/plinder/core/__init__.py
+++ b/src/plinder/core/__init__.py
@@ -6,10 +6,10 @@ from pathlib import Path
 _root = Path(__file__).parent.parent
 
 from plinder.core.index.utils import get_manifest, get_plindex
+from plinder.core.loader.loader import PlinderDataset
 from plinder.core.split.utils import get_split
 from plinder.core.system.system import PlinderSystem
 from plinder.core.utils.config import get_config
-from plinder.core.loader.loader import PlinderDataset
 
 __all__ = [
     "get_config",

--- a/src/plinder/core/__init__.py
+++ b/src/plinder/core/__init__.py
@@ -26,7 +26,7 @@ except (ImportError, ModuleNotFoundError):
             """
         )
     )
-    PlinderDataset = None
+    PlinderDataset = None  # type: ignore
 
 __all__ = [
     "get_config",

--- a/src/plinder/core/loader/loader.py
+++ b/src/plinder/core/loader/loader.py
@@ -73,7 +73,7 @@ class PlinderDataset(Dataset):  # type: ignore
             item["path"] = s.system_cif
 
         if self.load_alternative_structures:
-            if s.linked_structures is not None:
+            if s.linked_structures is not None and not s.linked_structures.empty:
                 links = s.linked_structures.groupby("kind")
                 for kind, group in links:
                     for link_id in group["id"].values[

--- a/src/plinder/core/loader/loader.py
+++ b/src/plinder/core/loader/loader.py
@@ -8,7 +8,7 @@ import atom3d.util.formats as fo
 import pandas as pd
 from torch.utils.data import Dataset
 
-from plinder.core import get_split
+from plinder.core.split.utils import get_split
 from plinder.core.system import system
 
 

--- a/src/plinder/core/scores/links.py
+++ b/src/plinder/core/scores/links.py
@@ -12,7 +12,6 @@ from plinder.core.utils import cpl
 from plinder.core.utils.config import get_config
 from plinder.core.utils.dec import timeit
 from plinder.core.utils.log import setup_logger
-from plinder.core.utils.schemas import STRUCTURE_LINK_SCHEMA
 
 LOG = setup_logger(__name__)
 
@@ -44,7 +43,6 @@ def query_links(
         dataset=dataset,
         filters=filters,
         columns=columns or ["*"],
-        schema=STRUCTURE_LINK_SCHEMA,
         allow_no_filters=True,
         include_filename=True,
     )

--- a/src/plinder/core/system/system.py
+++ b/src/plinder/core/system/system.py
@@ -141,19 +141,6 @@ class PlinderSystem:
         return (self.archive / "receptor.pdb").as_posix()
 
     @property
-    def system_pdb(self) -> str:
-        """
-        Path to the system.pdb file
-
-        Returns
-        -------
-        str
-            path
-        """
-        assert self.archive is not None
-        return (self.archive / "system.pdb").as_posix()
-
-    @property
     def sequences(self) -> str:
         """
         Path to the sequences.fasta file

--- a/src/plinder/core/system/system.py
+++ b/src/plinder/core/system/system.py
@@ -11,8 +11,6 @@ import pandas as pd
 
 from plinder.core.index import utils
 from plinder.core.scores.links import query_links
-from plinder.core.utils import cpl
-from plinder.core.utils.config import get_config
 from plinder.core.utils.log import setup_logger
 from plinder.core.utils.unpack import get_zips_to_unpack
 
@@ -245,11 +243,18 @@ class PlinderSystem:
         if self._linked_structures is None:
             links = query_links(filters=[("reference_system_id", "==", self.system_id)])
             self._linked_structures = links
-            if self._linked_structures is not None and not self._linked_structures.empty:
-                zips = get_zips_to_unpack(kind="linked_structures", system_ids=[self.system_id])
+            if (
+                self._linked_structures is not None
+                and not self._linked_structures.empty
+            ):
+                zips = get_zips_to_unpack(
+                    kind="linked_structures", system_ids=[self.system_id]
+                )
                 [archive] = list(zips.keys())
                 self._linked_archive = archive.parent
-                if not (self._linked_archive / "apo" / self.system_id).is_dir() or not (self._linked_archive / "pred" / self.system_id).is_dir():
+                if not (self._linked_archive / "apo" / self.system_id).is_dir() or not (
+                    self._linked_archive / "pred" / self.system_id
+                ).is_dir():
                     with ZipFile(archive) as arch:
                         arch.extractall(path=archive.parent)
         return self._linked_structures

--- a/src/plinder/core/system/system.py
+++ b/src/plinder/core/system/system.py
@@ -44,7 +44,7 @@ class PlinderSystem:
         self._chain_mapping = None
         self._water_mapping = None
         self._linked_structures = None
-        self._linked_archive = None
+        self._linked_archive: Path | None = None
 
     @property
     def entry(self) -> dict[str, Any] | None:
@@ -245,7 +245,7 @@ class PlinderSystem:
         if self._linked_structures is None:
             links = query_links(filters=[("reference_system_id", "==", self.system_id)])
             self._linked_structures = links
-            if not self._linked_structures.empty:
+            if self._linked_structures is not None and not self._linked_structures.empty:
                 zips = get_zips_to_unpack(kind="linked_structures", system_ids=[self.system_id])
                 [archive] = list(zips.keys())
                 self._linked_archive = archive.parent

--- a/src/plinder/core/system/system.py
+++ b/src/plinder/core/system/system.py
@@ -48,6 +48,14 @@ class PlinderSystem:
 
     @property
     def entry(self) -> dict[str, Any] | None:
+        """
+        Store a reference to the entry JSON for this system
+
+        Returns
+        -------
+        dict[str, Any] | None
+            entry JSON
+        """
         if self._entry is None:
             entry_pdb_id = self.system_id.split("__")[0]
             try:
@@ -59,6 +67,14 @@ class PlinderSystem:
 
     @property
     def system(self) -> dict[str, Any] | None:
+        """
+        Return the system metadata from the original entry JSON
+
+        Returns
+        -------
+        dict[str, Any] | None
+            system metadata
+        """
         if self._system is None:
             try:
                 assert self.entry is not None
@@ -69,6 +85,14 @@ class PlinderSystem:
 
     @property
     def archive(self) -> Path | None:
+        """
+        Return the path to the directory containing the plinder system
+
+        Returns
+        -------
+        Path | None
+            directory containing the plinder system
+        """
         if self._archive is None:
             zips = get_zips_to_unpack(kind="systems", system_ids=[self.system_id])
             [archive] = list(zips.keys())
@@ -81,31 +105,79 @@ class PlinderSystem:
 
     @property
     def system_cif(self) -> str:
+        """
+        Path to the system.cif file
+
+        Returns
+        -------
+        str
+            path
+        """
         assert self.archive is not None
         return (self.archive / "system.cif").as_posix()
 
     @property
     def receptor_cif(self) -> str:
+        """
+        Path to the receptor.cif file
+
+        Returns
+        -------
+        str
+            path
+        """
         assert self.archive is not None
         return (self.archive / "receptor.cif").as_posix()
 
     @property
     def receptor_pdb(self) -> str:
+        """
+        Path to the receptor.pdb file
+
+        Returns
+        -------
+        str
+            path
+        """
         assert self.archive is not None
         return (self.archive / "receptor.pdb").as_posix()
 
     @property
     def system_pdb(self) -> str:
+        """
+        Path to the system.pdb file
+
+        Returns
+        -------
+        str
+            path
+        """
         assert self.archive is not None
         return (self.archive / "system.pdb").as_posix()
 
     @property
     def sequences(self) -> str:
+        """
+        Path to the sequences.fasta file
+
+        Returns
+        -------
+        str
+            path
+        """
         assert self.archive is not None
         return (self.archive / "sequences.fasta").as_posix()
 
     @property
     def chain_mapping(self) -> dict[str, Any] | None:
+        """
+        Chain mapping metadata
+
+        Returns
+        -------
+        dict[str, Any] | None
+            chain mapping
+        """
         if self._chain_mapping is None:
             assert self.archive is not None
             with (self.archive / "chain_mapping.json").open() as f:
@@ -114,6 +186,14 @@ class PlinderSystem:
 
     @property
     def water_mapping(self) -> dict[str, Any] | None:
+        """
+        Water mapping metadata
+
+        Returns
+        -------
+        dict[str, Any] | None
+            water mapping
+        """
         if self._water_mapping is None:
             assert self.archive is not None
             with (self.archive / "water_mapping.json").open() as f:
@@ -122,6 +202,14 @@ class PlinderSystem:
 
     @property
     def ligands(self) -> dict[str, str]:
+        """
+        Return a dictionary of ligand names to paths to ligand sdf files
+
+        Returns
+        -------
+        dict[str, str]
+            dictionary of ligand names to paths to ligand sdf files
+        """
         assert self.archive is not None
         ligands = {}
         for ligand in (self.archive / "ligand_files/").glob("*.sdf"):
@@ -130,37 +218,80 @@ class PlinderSystem:
 
     @property
     def structures(self) -> list[str]:
+        """
+        Return a list of paths to all structures in the plinder system
+
+        Returns
+        -------
+        list[str]
+            list of paths to structures
+        """
         assert self.archive is not None
         return [path.as_posix() for path in self.archive.rglob("*") if path.is_file()]
 
     @property
     def linked_structures(self) -> pd.DataFrame | None:
+        """
+        Return a dataframe of linked structures for this system. Note
+        that the dataframe will include all of the scores for the linked
+        structures as well, so that particular alternatives can be chosen
+        accordingly.
+
+        Returns
+        -------
+        pd.DataFrame | None
+            dataframe of linked structures if present in plinder
+        """
         if self._linked_structures is None:
-            links = query_links(filters=[("query_system", "==", self.system_id)])
+            links = query_links(filters=[("reference_system_id", "==", self.system_id)])
             self._linked_structures = links
+            if not self._linked_structures.empty:
+                zips = get_zips_to_unpack(kind="linked_structures", system_ids=[self.system_id])
+                [archive] = list(zips.keys())
+                self._linked_archive = archive.parent
+                if not (self._linked_archive / "apo" / self.system_id).is_dir() or not (self._linked_archive / "pred" / self.system_id).is_dir():
+                    with ZipFile(archive) as arch:
+                        arch.extractall(path=archive.parent)
         return self._linked_structures
 
     @property
     def linked_archive(self) -> Path | None:
-        if self._linked_archive is None:
-            cfg = get_config()
-            self._linked_archive = cpl.get_plinder_path(rel=cfg.data.linked_structures)  # type: ignore
-            assert self._linked_archive is not None
-            if not (self._linked_archive / "apo").is_dir():
-                with ZipFile(self._linked_archive) as arch:
-                    arch.extractall(path=self._linked_archive)
+        """
+        Path to linked structures archive if it exists
+
+        Returns
+        -------
+        Path | None
+            path to linked structures archive
+        """
+        self.linked_structures
         return self._linked_archive
 
-    def get_linked_structure(
-        self, link_kind: str, link_id: str, ext: str = "cif"
-    ) -> str:
-        if ext not in ["cif", "pdb"]:
-            raise ValueError(f"extension must be cif or pdb, got {ext}")
-        assert self.linked_archive is not None
-        return (
+    def get_linked_structure(self, link_kind: str, link_id: str) -> str:
+        """
+        Get the path to the requested linked structure
+
+        Parameters
+        ----------
+        link_kind : str
+            kind of linked structure ('apo' or 'pred')
+        link_id : str
+            id of linked structure
+
+        Returns
+        -------
+        str
+            path to linked structure
+        """
+        if self.linked_archive is None:
+            raise ValueError("linked_archive is None!")
+        structure = (
             self.linked_archive
             / link_kind
             / self.system_id
             / link_id
-            / "receptor.{ext}"
-        ).as_posix()
+            / "superposed.cif"
+        )
+        if not structure.is_file():
+            raise ValueError(f"structure={structure} does not exist!")
+        return structure.as_posix()

--- a/src/plinder/core/utils/config.py
+++ b/src/plinder/core/utils/config.py
@@ -214,10 +214,10 @@ class DataConfig:
     """
 
     plinder_release: str = field(
-        default_factory=partial(_getenv_default, "PLINDER_RELEASE", "2024-04")
+        default_factory=partial(_getenv_default, "PLINDER_RELEASE", "2024-06")
     )
     plinder_iteration: str = field(
-        default_factory=partial(_getenv_default, "PLINDER_ITERATION", "v1")
+        default_factory=partial(_getenv_default, "PLINDER_ITERATION", "v2")
     )
     plinder_mount: str = field(
         default_factory=partial(

--- a/src/plinder/core/utils/cpl.py
+++ b/src/plinder/core/utils/cpl.py
@@ -149,7 +149,7 @@ def get_plinder_path(*, rel: str = "", download: bool = True) -> Path:
         return Path(path.fspath)
     except OverwriteNewerLocalError:
         if path._local.exists():
-            return path._local
+            return Path(path._local)
         else:
             raise
 

--- a/src/plinder/core/utils/schemas.py
+++ b/src/plinder/core/utils/schemas.py
@@ -79,6 +79,8 @@ SPLIT_DATASET_SCHEMA = pa.schema(
 
 
 # subject to criteria used in save_linked_structures.py
+# TODO: this schema is now out of date since addition of
+#       scores.json contents but it now contains >50 columns
 STRUCTURE_LINK_SCHEMA = pa.schema(
     [
         ("query_system", pa.string()),

--- a/src/plinder/core/utils/unpack.py
+++ b/src/plinder/core/utils/unpack.py
@@ -10,7 +10,7 @@ from omegaconf import DictConfig
 from plinder.core.utils import cpl
 from plinder.core.utils.config import get_config
 
-ZIP_KINDS = Literal["entries", "systems"]
+ZIP_KINDS = Literal["entries", "linked_structures", "systems"]
 ID_KINDS = Literal["system_ids", "pdb_ids", "two_char_code"]
 
 

--- a/src/plinder/data/__init__.py
+++ b/src/plinder/data/__init__.py
@@ -3,7 +3,7 @@
 from textwrap import dedent
 
 try:
-    import ost
+    import ost  # noqa
 except (ImportError, ModuleNotFoundError):
     raise ImportError(
         dedent(
@@ -16,7 +16,7 @@ except (ImportError, ModuleNotFoundError):
     )
 
 try:
-    import networkit
+    import networkit  # noqa
 except (ImportError, ModuleNotFoundError):
     raise ImportError(
         dedent(

--- a/src/plinder/data/__init__.py
+++ b/src/plinder/data/__init__.py
@@ -1,2 +1,29 @@
 # Copyright (c) 2024, Plinder Development Team
 # Distributed under the terms of the Apache License 2.0
+from textwrap import dedent
+
+try:
+    import ost
+except (ImportError, ModuleNotFoundError):
+    raise ImportError(
+        dedent(
+            """\
+            plinder.data requires the OpenStructureToolkit (ost) to be installed.
+            Please refer to the documentation for installation instructions and current limitations.
+            See the note here: https://github.com/plinder-org/plinder?tab=readme-ov-file#-getting-started
+            """
+        )
+    )
+
+try:
+    import networkit
+except (ImportError, ModuleNotFoundError):
+    raise ImportError(
+        dedent(
+            """\
+            plinder.data requires the networkit library to be installed.
+            Please refer to the documentation for installation instructions and current limitations.
+            See the note here: https://github.com/plinder-org/plinder?tab=readme-ov-file#-getting-started
+            """
+        )
+    )

--- a/src/plinder/data/pipeline/pipeline.py
+++ b/src/plinder/data/pipeline/pipeline.py
@@ -341,8 +341,8 @@ class IngestPipeline:
         tasks.assign_apo_pred_systems(
             data_dir=self.plinder_dir,
             # TODO: pass this and cpu in from config
-            search_db="holo",
             cpu=self.cfg.flow.assign_apo_pred_systems_cpus,
+            search_dbs=self.cfg.scorer.sub_databases,
         )
 
     def run_stage(self, stage: str) -> None:

--- a/src/plinder/data/pipeline/tasks.py
+++ b/src/plinder/data/pipeline/tasks.py
@@ -756,12 +756,11 @@ def collate_partitions(*, data_dir: Path, partition: list[str]) -> None:
     con.sql(f"set temp_directory='/plinder/tmp/{part}';")
 
     search_db = "holo"
-    src = "*.parquet"
-    tgt = "*.parquet"
+    src = f"*{part}.parquet"
+    tgt = f"{part}.parquet"
     if part in ["apo", "pred"]:
         search_db = part
-        src = f"*{part}.parquet"
-        tgt = f"{part}.parquet"
+        src = "*.parquet"
     score_dir = data_dir / "scores" / f"search_db={search_db}"
     source_dir = data_dir / "dbs" / "subdbs" / f"search_db={search_db}"
     source = f"{source_dir}/{src}"
@@ -772,7 +771,7 @@ def collate_partitions(*, data_dir: Path, partition: list[str]) -> None:
         dedent(
             f"""
                 COPY
-                    (select * from '{source}' order by metric, similarity desc)
+                    (select * from '{source}')
                 TO
                     '{target}'
                 (FORMAT PARQUET, ROW_GROUP_SIZE 500_000);

--- a/src/plinder/data/pipeline/tasks.py
+++ b/src/plinder/data/pipeline/tasks.py
@@ -1007,7 +1007,7 @@ def compute_protein_leakage(
 def assign_apo_pred_systems(
     *,
     data_dir: Path,
-    search_db: str,
+    search_dbs: list[str],
     cpu: int = 8,
 ) -> None:
     from plinder.data.save_linked_structures import (
@@ -1017,7 +1017,7 @@ def assign_apo_pred_systems(
 
     save_dir = data_dir / "assignments"
     linked_structures = data_dir / "linked_structures"
-    for search_db in ["apo", "pred"]:
+    for search_db in search_dbs:
         output_file = linked_structures / f"{search_db}_links.parquet"
         make_linked_structures_data_file(
             data_dir=data_dir,

--- a/src/plinder/data/pipeline/utils.py
+++ b/src/plinder/data/pipeline/utils.py
@@ -555,11 +555,15 @@ def pack_linked_structures(data_dir: Path, code: str) -> None:
         two character code
     """
     (data_dir / "links").mkdir(exist_ok=True, parents=True)
-    with ZipFile(data_dir / "links" / f"{code}.zip", "w", compression=ZIP_DEFLATED) as archive:
+    with ZipFile(
+        data_dir / "links" / f"{code}.zip", "w", compression=ZIP_DEFLATED
+    ) as archive:
         for search_db in ["apo", "pred"]:
             jsons = []
             root = data_dir / "linked_structures" / search_db
-            system_ids = [system_id for system_id in listdir(root) if system_id[1:3] == code]
+            system_ids = [
+                system_id for system_id in listdir(root) if system_id[1:3] == code
+            ]
             for system_id in system_ids:
                 link_ids = listdir(f"{root}/{system_id}")
                 for link_id in link_ids:
@@ -576,8 +580,12 @@ def pack_linked_structures(data_dir: Path, code: str) -> None:
                         )
                     except Exception:
                         pass
-            df = pd.DataFrame(jsons).rename(columns={"reference": "reference_system_id", "model": "id"})
-            df.to_parquet(data_dir / "links" / f"{search_db}_{code}.parquet", index=False)
+            df = pd.DataFrame(jsons).rename(
+                columns={"reference": "reference_system_id", "model": "id"}
+            )
+            df.to_parquet(
+                data_dir / "links" / f"{search_db}_{code}.parquet", index=False
+            )
 
 
 def mp_pack_linked_structures(*, data_dir: Path) -> None:
@@ -591,7 +599,9 @@ def mp_pack_linked_structures(*, data_dir: Path) -> None:
     """
 
     with multiprocessing.get_context("spawn").Pool() as pool:
-        pool.starmap(pack_linked_structures, zip(repeat(data_dir), listdir(data_dir / "ingest")))
+        pool.starmap(
+            pack_linked_structures, zip(repeat(data_dir), listdir(data_dir / "ingest"))
+        )
 
 
 def consolidate_linked_scores(*, data_dir: Path) -> None:
@@ -612,7 +622,9 @@ def consolidate_linked_scores(*, data_dir: Path) -> None:
             if not df.empty:
                 dfs.append(df)
         ndf = pd.concat(dfs)
-        odf = pd.read_parquet(data_dir / "linked_structures" / f"{search_db}_links.parquet")
+        odf = pd.read_parquet(
+            data_dir / "linked_structures" / f"{search_db}_links.parquet"
+        )
         df = pd.merge(odf, ndf, on=["reference_system_id", "id"])
         df.to_parquet(data_dir / "links" / f"{search_db}_links.parquet", index=False)
 

--- a/src/plinder/data/pipeline/utils.py
+++ b/src/plinder/data/pipeline/utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import multiprocessing
+import shutil
 from functools import wraps
 from hashlib import md5
 from itertools import repeat
@@ -541,7 +542,7 @@ def create_nonredundant_dataset(*, data_dir: Path) -> None:
     )
 
 
-def pack_linked_structures(*, data_dir: Path, code: str) -> None:
+def pack_linked_structures(data_dir: Path, code: str) -> None:
     """
     Pack generated linked structures into a zip file for a particular
     two character code.
@@ -614,3 +615,24 @@ def consolidate_linked_scores(*, data_dir: Path) -> None:
         odf = pd.read_parquet(data_dir / "linked_structures" / f"{search_db}_links.parquet")
         df = pd.merge(odf, ndf, on=["reference_system_id", "id"])
         df.to_parquet(data_dir / "links" / f"{search_db}_links.parquet", index=False)
+
+
+def rename_clusters(*, data_dir: Path) -> None:
+    """
+    Rename cluster files to match the hive layout convention.
+
+    Parameters
+    ----------
+    data_dir : Path
+        plinder root dir
+    """
+    cluster_dir = data_dir / "clusters"
+    cluster_paths = [path for path in cluster_dir.rglob("*") if path.is_file()]
+    for path in cluster_paths:
+        if path.name == "data.parquet":
+            continue
+        base = path.parent
+        name = path.stem
+        apath = base / name / "data.parquet"
+        apath.parent.mkdir(exist_ok=True, parents=True)
+        shutil.move(path, apath)

--- a/src/plinder/data/save_linked_structures.py
+++ b/src/plinder/data/save_linked_structures.py
@@ -67,7 +67,9 @@ def superpose_to_system(
         Chain of the target asymmetric unit to superpose
     """
     # Load target asymmetric unit and chain
-    target_mol, info = io.LoadMMCIF(target_cif_file.as_posix(), info=True, fault_tolerant=True)
+    target_mol, info = io.LoadMMCIF(
+        target_cif_file.as_posix(), info=True, fault_tolerant=True
+    )
     if target_chain is not None:
         target_mol = mol.CreateEntityFromView(
             target_mol.Select(f"chain='{target_chain}'"), True

--- a/src/plinder/data/save_linked_structures.py
+++ b/src/plinder/data/save_linked_structures.py
@@ -67,7 +67,7 @@ def superpose_to_system(
         Chain of the target asymmetric unit to superpose
     """
     # Load target asymmetric unit and chain
-    target_mol, info = io.LoadMMCIF(target_cif_file.as_posix(), info=True)
+    target_mol, info = io.LoadMMCIF(target_cif_file.as_posix(), info=True, fault_tolerant=True)
     if target_chain is not None:
         target_mol = mol.CreateEntityFromView(
             target_mol.Select(f"chain='{target_chain}'"), True

--- a/src/plinder/eval/docking/utils.py
+++ b/src/plinder/eval/docking/utils.py
@@ -113,7 +113,12 @@ class ModelScores:
         score_protein: bool = False,
         score_posebusters: bool = False,
     ) -> "ModelScores":
-        entity = io.LoadEntity(model_file.as_posix())
+        if model_file.suffix not in [".cif", ".pdb"]:
+            raise ValueError(f"model_file must be a .cif or .pdb file, got {model_file}")
+        if model_file.suffix == ".cif":
+            entity = io.LoadMMCIF(model_file.as_posix(), fault_tolerant=True)
+        else:
+            entity = io.LoadPDB(model_file.as_posix(), fault_tolerant=True)
         sdf_files = [
             sdf_file.as_posix() if isinstance(sdf_file, Path) else sdf_file
             for sdf_file in model_ligand_sdf_files

--- a/src/plinder/eval/docking/utils.py
+++ b/src/plinder/eval/docking/utils.py
@@ -114,7 +114,9 @@ class ModelScores:
         score_posebusters: bool = False,
     ) -> "ModelScores":
         if model_file.suffix not in [".cif", ".pdb"]:
-            raise ValueError(f"model_file must be a .cif or .pdb file, got {model_file}")
+            raise ValueError(
+                f"model_file must be a .cif or .pdb file, got {model_file}"
+            )
         if model_file.suffix == ".cif":
             entity = io.LoadMMCIF(model_file.as_posix(), fault_tolerant=True)
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -634,6 +634,8 @@ def read_plinder_mount(monkeypatch):
     monkeypatch.setenv("PLINDER_RELEASE", "mount")
     monkeypatch.setenv("PLINDER_BUCKET", "plinder")
     monkeypatch.setenv("PLINDER_ITERATION", "")
+    config.get_config(cached=False)
+
     return plinder_mount
 
 

--- a/tests/core/test_core_system.py
+++ b/tests/core/test_core_system.py
@@ -31,14 +31,12 @@ def test_plinder_system_system_files(read_plinder_mount):
     assert len(s.structures) == 10
     assert len(s.ligands) == 3
     assert len(s.system_cif)
-    assert len(s.system_pdb)
     assert len(s.receptor_cif)
     assert len(s.receptor_pdb)
     assert len(s.sequences)
     assert len(s.chain_mapping)
     assert len(s.water_mapping)
     assert Path(s.system_cif).is_file()
-    assert Path(s.system_pdb).is_file()
     assert Path(s.receptor_cif).is_file()
     assert Path(s.receptor_pdb).is_file()
     assert Path(s.sequences).is_file()


### PR DESCRIPTION
This PR introduces a small bugfix for pred superposed linked structure generation. It also contains some utilities for archiving the linked structures similar to how systems are currently managed in `plinder.core`.

To Do:
- [x] Ensure the data loader can consume the newly packaged format for linked structures