### PR TITLE
Prettify annotation table

### DIFF
--- a/column_descriptions/entry_information.tsv
+++ b/column_descriptions/entry_information.tsv
@@ -5,4 +5,4 @@ entry_oligomeric_state	str	 Author's provided description of quaternary structur
 entry_pH	float	 pH at which structure is solved. See https://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items/_exptl_crystal_grow.pH.html
 entry_pdb_id	str	 RCSB PDB ID. See https://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items/_entry.id.html
 entry_release_date	str	 RCSB structure release date. See https://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items/_database_PDB_rev.date_original.html
-entry_resolution	str	 RCSB structure resolution. See https://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items/_refine.ls_d_res_high.html
+entry_resolution	float	 RCSB structure resolution. See https://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items/_refine.ls_d_res_high.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,18 +79,11 @@ html_theme = "pydata_sphinx_theme"
 html_static_path = ["static"]
 html_css_files = [
     "plinder.css",
-    # For rendering the column descriptions table
-    "https://cdn.datatables.net/2.1.3/css/dataTables.dataTables.css",
     # Get fonts from Google Fonts CDN
     "https://fonts.googleapis.com/css2"
     "?family=Geologica:wght@100..900"
     "&family=Montserrat:ital,wght@0,100..900;1,100..900"
     "&display=swap",
-]
-html_js_files = [
-    # For rendering the column descriptions table
-    "https://code.jquery.com/jquery-3.7.1.js",
-    "https://cdn.datatables.net/2.1.3/js/dataTables.js",
 ]
 html_title = "PLINDER"
 html_logo = "static/assets/general/plinder_logo.png"

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -77,7 +77,7 @@ Tables that lists all systems along with their annotations.
 :::{include} table.html
 :::
 
-`Mandatory` means, that the column has a value in all PLINDER systems.
+`Mandatory`: The column has a non-empty, non-NaN value in for all PLINDER systems.
 
 
 ### Clusters (`clusters/`)

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -70,12 +70,15 @@ Tables that lists all systems along with their annotations.
 - Add `Example` column
 - Sort by mandatory columns
 - Show `system_id` as first column
-- Plugin [datatables](https://datatables.net/) to enable sorting, filtering and pagination
 - Then customize table style to fit all columns into the page
 :::
 
+
 :::{include} table.html
 :::
+
+`Mandatory` means, that the column has a value in all PLINDER systems.
+
 
 ### Clusters (`clusters/`)
 

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -65,15 +65,6 @@ Tables that lists all systems along with their annotations.
 - `annotation_table.parquet`: Lists all systems and their annotations.
 - `annotation_table_nonredundant.parquet`: Subset of systems without redundant systems.
 
-:::{todo}
-- Add `Mandatory` column
-- Add `Example` column
-- Sort by mandatory columns
-- Show `system_id` as first column
-- Then customize table style to fit all columns into the page
-:::
-
-
 :::{include} table.html
 :::
 

--- a/docs/static/plinder.css
+++ b/docs/static/plinder.css
@@ -34,11 +34,36 @@ html[data-theme="dark"] {
     padding-bottom: 30px;
 }
 
+/* The tutorial buttons on the home page */
 .main-button {
     padding-right: 20px;
     align-self: center;
 }
 
+/* The tutorial button icons on the home page */
 svg.main-button-icon path {
     fill: var(--pst-color-primary);
+}
+
+/* The cross/check marks in the annotation table*/
+svg.marks {
+    height: 32px;
+}
+
+.dt-container table,.pst-scrollable-table-container table {
+    font-size: small;
+}
+
+/* The annotation table column containing the cross/check marks */
+table.dataTable td.dt-type-numeric {
+    text-align: center !important;
+}
+
+
+/* The `Example` column in the annotation table */
+.example {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 150px;
 }

--- a/docs/tablegen.py
+++ b/docs/tablegen.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 from glob import glob
 from pathlib import Path
-from xml.etree import ElementTree
 
 import pandas as pd
+from itables import to_html_datatable
+
+ROWS_PER_PAGE = 10
+
+CHECKMARK = '<svg class="marks" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="#da5da4" d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>'
+CROSSMARK = '<svg class="marks" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="#cccccc" d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"/></svg>'
 
 
 def generate_table(description_dir: Path, output_html_path: Path) -> None:
@@ -27,40 +32,114 @@ def generate_table(description_dir: Path, output_html_path: Path) -> None:
             column_descriptions_in_file = pd.read_csv(f, sep="\t")
         column_descriptions.append(column_descriptions_in_file)
     column_descriptions = pd.concat(column_descriptions, ignore_index=True)
-    _write_table(
+
+    column_descriptions["Mandatory"] = [True] * column_descriptions.shape[0]
+    column_descriptions["Example"] = [
+        '"aasdnkasdhjkashdkhaskjdhashkdhjaksdhkashjd"'
+    ] * column_descriptions.shape[0]
+
+    column_descriptions["Name"] = _to_monospace(column_descriptions["Name"])
+    column_descriptions["Type"] = _to_monospace(column_descriptions["Type"])
+    column_descriptions["Mandatory"] = _to_marks(column_descriptions["Mandatory"])
+    column_descriptions["Example"] = _to_example(_to_monospace(
+        column_descriptions["Example"])
+    )  # fmt: skip
+
+    html = to_html_datatable(
         column_descriptions,
-        output_html_path,
-        # 'table' class is also used by Sphinx for all other tables,
-        # hence this class applies the same styling to this table as well.
-        table_class="table",
-        table_id="tableReference",
+        display_logo_when_loading=False,
+        # Only one value, as the user can't change the number of rows
+        lengthMenu=[ROWS_PER_PAGE],
+        layout={
+            "topStart": "search",
+            "topEnd": "paging",
+            "bottomStart": None,
+            "bottomEnd": None,
+        },
+        # Use 'table' class from pydata theme to inherit the style of the usual tables
+        classes="table display compact",
+        # Without setting width to 100%,
+        # the table would get a small horizontal scrollbar
+        style="width:100%;overflow-wrap:break-word",
+        autoWidth=False,
     )
-
-
-def _write_table(
-    column_descriptions: pd.DataFrame,
-    output_html_path: Path,
-    table_class: str | None = None,
-    table_id: str | None = None,
-) -> None:
-    table = ElementTree.Element("table")
-    if table_id is not None:
-        table.set("id", table_id)
-    if table_class is not None:
-        table.set("class", table_class)
-
-    thead = ElementTree.SubElement(table, "thead")
-    tr = ElementTree.SubElement(thead, "tr")
-    for column_name in column_descriptions.columns:
-        th = ElementTree.SubElement(tr, "th")
-        th.text = column_name
-
-    tbody = ElementTree.SubElement(table, "tbody")
-    for _, row in column_descriptions.iterrows():
-        tr = ElementTree.SubElement(tbody, "tr")
-        for column_name, value in row.items():
-            td = ElementTree.SubElement(tr, "td")
-            td.text = str(value)
-
     with open(output_html_path, "w") as f:
-        f.write(ElementTree.tostring(table).decode())
+        # Inline HTML in Markdown does not allow empty lines
+        f.write(_remove_empty_lines(html))
+
+
+def _remove_empty_lines(string: str) -> str:
+    """
+    Remove empty lines from a multiline string.
+
+    Parameters
+    ----------
+    html : str
+        HTML string.
+
+    Returns
+    -------
+    str
+        HTML string without empty lines.
+    """
+    return "\n".join(line for line in string.splitlines() if len(line.strip()) != 0)
+
+
+def _to_monospace(values: pd.Series) -> pd.Series:
+    """
+    Convert a series of strings to monospace.
+
+    Parameters
+    ----------
+    values : pd.Series
+        Series of strings.
+
+    Returns
+    -------
+    pd.Series
+        Series of strings in monospace.
+    """
+    return values.map(lambda x: f"<code>{x}</code>")
+
+
+def _to_marks(values: pd.Series) -> pd.Series:
+    """
+    Convert a series of booleans to check/cross marks.
+
+    Parameters
+    ----------
+    values : pd.Series
+        Series of booleans.
+
+    Returns
+    -------
+    pd.Series
+        Series of check/cross marks.
+    """
+    return values.map(lambda x: CHECKMARK if x else CROSSMARK)
+
+
+def _to_example(values: pd.Series) -> pd.Series:
+    """
+    Put the given series of text into a `div` with the `.example` class.
+
+    Parameters
+    ----------
+    values : pd.Series
+        Series of strings.
+
+    Returns
+    -------
+    pd.Series
+        Series of strings in a `div` with the `.example` class.
+    """
+    return values.map(lambda x: f'<div class="example">{x}</div>')
+
+
+"""
+show(
+    annotations,
+    classes="cell-border",
+    columns= [{ "width": '10%' }, None, None, None, None]
+)
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ loader = [
     "atom3d",
 ]
 docs = [
+    "itables",
     "jupyter-sphinx",
     "jupyterlab_myst",
     "jupytext",


### PR DESCRIPTION
This PR improves the main annotation table rendered in the dataset reference in the docs.

- The table is now rendered with `itables` to make it fitlerable, sortable and shorter.
- A `Mandatory` column is added
- An `Example` column is added