### PR TITLE
Add API reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,8 @@ instance/
 # Generated files in Sphinx documentation
 docs/_build/
 docs/table.html
+docs/api/core
+docs/api/scores
 
 # PyBuilder
 .pybuilder/

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,9 +1,0 @@
----
-sd_hide_title: true
----
-
-# Python API
-
-## API reference
-
-**Coming soon**

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -6,10 +6,9 @@ sd_hide_title: true
 
 ## API reference
 
-:::{todo}
-- Add a short description that the public API is split into two packages and
-  roughly what these packages do
-:::
+The ``plinder.core`` package provides utilities for interacting with the PLINDER dataset.
+
+It contains an additional ``plinder.core.scores`` sub-package for querying parquet collections.
 
 :::{toctree}
 :maxdepth: 1

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,20 @@
+---
+sd_hide_title: true
+---
+
+# Python API
+
+## API reference
+
+:::{todo}
+- Add a short description that the public API is split into two packages and
+  roughly what these packages do
+:::
+
+:::{toctree}
+:maxdepth: 1
+:hidden:
+
+core/index
+scores/index
+:::

--- a/docs/apidoc.py
+++ b/docs/apidoc.py
@@ -1,0 +1,245 @@
+# The code in this file is based on the file with the same name in the Biotite project
+# licensed under BSD-3-clause license.
+
+import enum
+import shutil
+import types
+from importlib import import_module
+from pathlib import Path
+from textwrap import dedent
+from types import ModuleType
+from typing import Any
+
+from sphinx.application import Sphinx
+
+_INDENT = " " * 4
+
+
+def generate_api_reference(package_name: str, output_dir: Path) -> None:
+    """
+    Create the API reference for the given package and store it in the output directory.
+
+    This creates `.rst` files containing `autodoc` directives.
+
+    Parameters
+    ----------
+    package_name : str
+        The name of the package to document.
+    output_dir : Path
+        The directory to store the generated files in.
+
+    Notes
+    -----
+    Use `.rst` files are `apidoc`and `numpydoc` produce reStructuredText formatted text.
+    """
+    package = import_module(package_name)
+    class_names = []
+    function_names = []
+    for attr_name in package.__all__:
+        if _is_public_class(package, attr_name):
+            class_names.append(attr_name)
+        elif _is_public_function(package, attr_name):
+            function_names.append(attr_name)
+
+    # Remove existing rst files
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    # Create rst files
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _create_package_page(
+        output_dir / "index.rst", package_name, class_names, function_names
+    )
+    for class_name in class_names:
+        _create_class_page(
+            output_dir / f"{package_name}.{class_name}.rst", package_name, class_name
+        )
+    for function_name in function_names:
+        _create_function_page(
+            output_dir / f"{package_name}.{function_name}.rst",
+            package_name,
+            function_name,
+        )
+
+
+def _create_package_page(
+    output_path: Path,
+    package_name: str,
+    classes: list[str],
+    functions: list[str],
+):
+    """
+    Create the `.rst` file for the package overview.
+
+    Parameters
+    ----------
+    output_path : Path
+        The path to the output file.
+    package_name : str
+        The name of the package as it would be imported.
+    classes, functions : list of str
+        The names of the classes and functions to be documented, that are attributes of
+        the package, respectively.
+    """
+    attributes = classes + functions
+    # Enumerate classes and functions
+    # `eval-rst` directive is necessary, as `autosummary` directive renders rst
+    summary_string = dedent(
+        """
+
+        .. autosummary::
+            :nosignatures:
+            :toctree:
+
+    """
+    )
+    summary_string += "\n".join([_INDENT + attr for attr in attributes])
+
+    # Assemble page
+    file_content = (
+        dedent(
+            f"""
+
+        ``{package_name}``
+        {"=" * (len(package_name) + 4)}
+        .. currentmodule:: {package_name}
+
+        .. automodule:: {package_name}
+
+        .. currentmodule:: {package_name}
+
+    """
+        )
+        + summary_string
+    )
+    with open(output_path, "w") as f:
+        f.write(file_content)
+
+
+def _create_class_page(output_path, package_name, class_name):
+    """
+    Create the `.rst` file for the given class.
+
+    Parameters
+    ----------
+    output_path : Path
+        The path to the output file.
+    package_name : str
+        The name of the package as it would be imported.
+    class_name : str
+        The name of the class to document, that is part of the package.
+    """
+    file_content = dedent(
+        f"""
+        :sd_hide_title: true
+
+        ``{class_name}``
+        {"=" * (len(class_name) + 4)}
+        .. autoclass:: {package_name}.{class_name}
+            :show-inheritance:
+            :members:
+            :member-order: bysource
+            :undoc-members:
+            :inherited-members:
+    """
+    )
+    with open(output_path, "w") as f:
+        f.write(file_content)
+
+
+def _create_function_page(output_path, package_name, function_name):
+    """
+    Create the `.rst` file for the given function.
+
+    Parameters
+    ----------
+    output_path : Path
+        The path to the output file.
+    package_name : str
+        The name of the package as it would be imported.
+    function_name : str
+        The name of the function to document, that is part of the package.
+    """
+    file_content = dedent(
+        f"""
+        :sd_hide_title: true
+
+        ``{function_name}``
+        {"=" * (len(function_name) + 4)}
+        .. autofunction:: {package_name}.{function_name}
+    """
+    ).strip()
+    with open(output_path, "w") as f:
+        f.write(file_content)
+
+
+def _is_public_class(module: ModuleType, attr_name: str) -> bool:
+    """
+    Check if the attribute is a public class.
+    """
+    return _is_public(attr_name) and isinstance(getattr(module, attr_name), type)
+
+
+def _is_public_function(module: ModuleType, attr_name: str) -> bool:
+    """
+    Check if the attribute is a public function.
+    """
+    return _is_public(attr_name) and callable(getattr(module, attr_name))
+
+
+def _is_public(attr_name: str) -> bool:
+    """
+    Check if the attribute is public.
+    """
+    return not attr_name.startswith("_")
+
+
+def skip_nonrelevant(
+    app: Sphinx, what: str, name: str, obj: Any, skip: bool, options: dict
+) -> bool:
+    """
+    Skip all class members, that are not methods, enum values or inner
+    classes, since other attributes are already documented in the class
+    docstring.
+
+    Furthermore, skip all class members, that are inherited from
+    non-PLINDER base classes.
+
+    See
+    https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#event-autodoc-skip-member
+    for more information.
+    """
+    if skip:
+        return True
+    if not _is_relevant_type(obj):
+        return True
+    if obj.__module__ is None:
+        # Some built-in functions have '__module__' set to None
+        return True
+    package_name = obj.__module__.split(".")[0]
+    if package_name != "plinder":
+        return True
+    return False
+
+
+def _is_relevant_type(obj: Any) -> bool:
+    """
+    Check if the given object is an attribute that is worth documenting.
+    """
+    if type(obj).__name__ == "method_descriptor":
+        # These are some special built-in Python methods
+        return False
+    return (
+        (
+            # Functions
+            type(obj)
+            in [types.FunctionType, types.BuiltinFunctionType, types.MethodType]
+        )
+        | (
+            # Enum instance
+            isinstance(obj, enum.Enum)
+        )
+        | (
+            # Inner class
+            isinstance(obj, type)
+        )
+    )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import plinder
 
 DOC_PATH = Path(__file__).parent
-PACKAGE_PATH = DOC_PATH.parent / "src"
 COLUMN_REFERENCE_PATH = DOC_PATH.parent / "column_descriptions"
 
 # Avoid verbose logs in rendered notebooks
@@ -14,9 +13,12 @@ os.environ["PLINDER_LOG_LEVEL"] = "0"
 # Include documentation in PYTHONPATH
 # in order to import modules for API doc generation etc.
 sys.path.insert(0, str(DOC_PATH))
+import apidoc
 import tablegen
 
 # Pregeneration of files
+apidoc.generate_api_reference("plinder.core", DOC_PATH / "api" / "core")
+apidoc.generate_api_reference("plinder.core.scores", DOC_PATH / "api" / "scores")
 tablegen.generate_table(COLUMN_REFERENCE_PATH, DOC_PATH / "table.html")
 
 #### Source code link ###
@@ -59,6 +61,11 @@ myst_enable_extensions = [
     "tasklist",
 ]
 myst_url_schemes = ("http", "https", "mailto")
+
+numpydoc_show_class_members = False
+# Prevent autosummary from using sphinx-autogen, since it would
+# overwrite the document structure given by apidoc.json
+autosummary_generate = False
 
 templates_path = ["templates"]
 source_suffix = {
@@ -131,5 +138,5 @@ html_context = {
 #### App setup ####
 
 
-# def setup(app):
-#    app.connect("autodoc-skip-member", apidoc.skip_nonrelevant)
+def setup(app):
+    app.connect("autodoc-skip-member", apidoc.skip_nonrelevant)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,6 +133,7 @@ html_context = {
     "github_version": "main",
     "doc_path": "doc",
 }
+html_scaled_image_link = False
 
 
 #### App setup ####

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@ os.environ["PLINDER_LOG_LEVEL"] = "0"
 sys.path.insert(0, str(DOC_PATH))
 import apidoc
 import tablegen
+import viewcode
 
 # Pregeneration of files
 apidoc.generate_api_reference("plinder.core", DOC_PATH / "api" / "core")
@@ -33,7 +34,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.doctest",
     "sphinx.ext.mathjax",
-    # "sphinx.ext.linkcode",
+    "sphinx.ext.linkcode",
     "sphinx.ext.todo",
     "sphinx_design",
     "sphinx_copybutton",
@@ -66,6 +67,7 @@ numpydoc_show_class_members = False
 # Prevent autosummary from using sphinx-autogen, since it would
 # overwrite the document structure given by apidoc.json
 autosummary_generate = False
+linkcode_resolve = viewcode.linkcode_resolve
 
 templates_path = ["templates"]
 source_suffix = {

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,14 +22,9 @@ resource for training and evaluation of protein-ligand docking algorithms:
 - Robust evaluation harness to simplify and standard performance comparison between models.
 
 
-::::::{grid} 3
-
-:::::{grid-item}
-:columns: 3
-:::::
+::::::{grid} 1 1 2 2
 
 :::::{grid-item-card}
-:columns: 6
 :link: tutorial/dataset
 :link-type: doc
 
@@ -51,31 +46,30 @@ Access the PLI systems and their annotations directly via the files
 :::::
 
 
-% :::::{grid-item-card}
-% :link: tutorial/api
-% :link-type: doc
-%
-% ::::{grid} 2
-%
-% :::{grid-item}
-% :columns: 3
-% :class: main-button
-% <svg class="main-button-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M392.8 1.2c-17-4.9-34.7 5-39.6 22l-128 448c-4.9 17 5 34.7 22 39.6s34.7-5 39.6-22l128-448c4.9-17-5-34.7-22-39.6zm80.6 120.1c-12.5 12.5-12.5 32.8 0 45.3L562.7 256l-89.4 89.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l112-112c12.5-12.5 12.5-32.8 0-45.3l-112-112c-12.5-12.5-32.8-12.5-45.3 0zm-306.7 0c-12.5-12.5-32.8-12.5-45.3 0l-112 112c-12.5 12.5-12.5 32.8 0 45.3l112 112c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L77.3 256l89.4-89.4c12.5-12.5 12.5-32.8 0-45.3z"/></svg>
-% :::
-%
-% :::{grid-item}
-% :columns: 9
-% **Python API**
-%
-% Use the dedicated Python package to explore the data
-% :::
-% ::::
-% :::::
+:::::{grid-item-card}
+:link: tutorial/api
+:link-type: doc
+
+::::{grid} 2
+
+:::{grid-item}
+:columns: 3
+:class: main-button
+<svg class="main-button-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M392.8 1.2c-17-4.9-34.7 5-39.6 22l-128 448c-4.9 17 5 34.7 22 39.6s34.7-5 39.6-22l128-448c4.9-17-5-34.7-22-39.6zm80.6 120.1c-12.5 12.5-12.5 32.8 0 45.3L562.7 256l-89.4 89.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l112-112c12.5-12.5 12.5-32.8 0-45.3l-112-112c-12.5-12.5-32.8-12.5-45.3 0zm-306.7 0c-12.5-12.5-32.8-12.5-45.3 0l-112 112c-12.5 12.5-12.5 32.8 0 45.3l112 112c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L77.3 256l89.4-89.4c12.5-12.5 12.5-32.8 0-45.3z"/></svg>
+:::
+
+:::{grid-item}
+:columns: 9
+**Python API**
+
+Use the dedicated Python package to explore the data
+:::
+::::
+:::::
 
 ::::::
 
-
-% TODO: re-add `contribution/index` and `api` to `toctree`
+% TODO: re-add `contribution/index`
 
 :::{toctree}
 :maxdepth: 1
@@ -83,6 +77,7 @@ Access the PLI systems and their annotations directly via the files
 
 tutorial/index
 dataset
+api
 evaluation
 contribution/index
 citation

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ Use the dedicated Python package to explore the data
 
 tutorial/index
 dataset
-api
+api/index
 evaluation
 contribution/index
 citation

--- a/docs/viewcode.py
+++ b/docs/viewcode.py
@@ -1,0 +1,41 @@
+# The code in this file is based on the file with the same name in the Biotite project
+# licensed under BSD-3-clause license.
+
+import inspect
+from importlib import import_module
+from typing import Any
+
+import plinder
+
+
+def linkcode_resolve(domain: str, info: dict[str, Any]) -> str | None:
+    """
+    See https://www.sphinx-doc.org/en/master/usage/extensions/linkcode.html.
+    """
+    version = plinder.__version__
+    base_url = f"https://github.com/plinder-org/plinder/blob/v{version}/src/"
+
+    if domain != "py":
+        return None
+
+    package_name = info["module"]
+    attr_name = info["fullname"]
+
+    package = import_module(package_name)
+    try:
+        attr = getattr(package, attr_name)
+    except AttributeError:
+        # The attribute is not defined within PLINDER or is part of a class
+        # -> do not provide a link
+        return None
+    attr = getattr(package, attr_name)
+    module = inspect.getmodule(attr)
+
+    try:
+        source_lines, first = inspect.getsourcelines(attr)
+    except TypeError:
+        # The attribute is some special object, e.g. a 'partial' object
+        return None
+    last = first + len(source_lines) - 1
+
+    return base_url + f"{module.__name__.replace('.', '/')}.py#L{first}-L{last}"

--- a/src/plinder/core/__init__.py
+++ b/src/plinder/core/__init__.py
@@ -1,5 +1,18 @@
 # Copyright (c) 2024, Plinder Development Team
 # Distributed under the terms of the Apache License 2.0
+"""
+The plinder.core package collects useful functions and classes for interacting
+with the PLINDER dataset. It manages app configuration and will automatically
+download (and / or sync) the dataset to a local cache in a lazy manner, when
+particular assets are requested. One side effect of this is that plinder.core
+will (by default) compare the MD5 checksums of files on disk and files in cloud
+storage when they are accessed.
+
+Note
+----
+You can disable the MD5 checksum comparison between local files and remote files
+by setting the environment variable `PLINDER_OFFLINE=true`.
+"""
 from pathlib import Path
 from textwrap import dedent
 

--- a/src/plinder/core/scores/__init__.py
+++ b/src/plinder/core/scores/__init__.py
@@ -1,5 +1,13 @@
 # Copyright (c) 2024, Plinder Development Team
 # Distributed under the terms of the Apache License 2.0
+"""
+The plinder.core.scores subpackage provides a consistent API for querying
+the various parquet collections in the PLINDER dataset. The preferred
+parquet reader engine is duckdb, but much of the code previously used
+pandas and pyarrow directly. The internal query API supports converting
+the same pyarrow query filters used in pd.read_parquet into raw SQL for
+duckdb to execute.
+"""
 from .clusters import query_clusters
 from .index import query_index
 from .ligand import cross_similarity as cross_ligand_similarity


### PR DESCRIPTION
This PR adds an API reference generated from the code. It comprises the user-faced part of `plinder.core` and `plinder.core.scores`.

I would need some help for the following parts:

- I think `plinder.core` and `plinder.core.scores` should have a module docstring in `__init__.py` that explains what the respective package is about.
- Similarly a short overview on the entire user-faced API would be helpful in `docs/api/index.md`
- Currently the docstrings of the public functions/classes misses some section in the docstring (e.g. `PlinderSystem` misses the `Attribute` section).
- For the functions that have a complete docstring, the descriptions are often quite generic, i.e. the docstring does not convey much more information than the function signature itself. I think more details would be helpful to new users (including me :wink:).
- Optionally doctests would be helpful in the docstrings, as the give users a graspable example how the functionality can be used.
- Note that `numpydoc` requires docstrings to be written in *reStructuredText* instead of *Markdown*. They are very similar but there are small nuances where they are different. For example monospace is formatted with double backticks instead of single ones.