### PR TITLE
Plinder system performance improvements

### DIFF
--- a/docs/tutorial/dataset.md
+++ b/docs/tutorial/dataset.md
@@ -6,8 +6,6 @@ The PLINDER data is accessible from a _Google Cloud Platform_
 [bucket](https://cloud.google.com/storage/docs/buckets), a container for cloud storage
 of data.
 The bucket URL of PLINDER is `gs://plinder`.
-To interact with the data, we
-[install `gsutil`](https://cloud.google.com/storage/docs/gsutil_install) first.
 
 The PLINDER dataset is versioned via two parameters:
 
@@ -17,14 +15,15 @@ The PLINDER dataset is versioned via two parameters:
 There are two ways to obtain the data:
 
 1. Use the `plinder` python package and corresponding API
+    - `pip install plinder`
 2. Use the `gsutil` command line tool directly
+   - [installing `gsutil`](https://cloud.google.com/storage/docs/gsutil_install)
 
 For the purpose of this tutorial we set `PLINDER_ITERATION` to `tutorial`, to download
 only a small manageable excerpt of the entries.
 
 Using the `plinder` package:
 ```bash
-pip install plinder
 # adding --yes will skip all confirmation prompts
 plinder_download --release 2024-06 --iteration tutorial --yes
 ```
@@ -78,6 +77,8 @@ $ gsutil -m cp -r gs://plinder/${PLINDER_RELEASE}/${PLINDER_ITERATION}/splits ~/
 ```
 
 ## Unpacking the structure files
+
+If you used the `plinder_download` command, you can skip this section.
 
 Similar to the
 [PDB NextGen Archive](https://www.wwpdb.org/ftp/pdb-nextgen-archive-site), we split the

--- a/docs/tutorial/dataset.md
+++ b/docs/tutorial/dataset.md
@@ -14,9 +14,22 @@ The PLINDER dataset is versioned via two parameters:
 - `PLINDER_RELEASE`: the time stamp of the last RCSB sync
 - `PLINDER_ITERATION`: iterative development within a release
 
+There are two ways to obtain the data:
+
+1. Use the `plinder` python package and corresponding API
+2. Use the `gsutil` command line tool directly
+
 For the purpose of this tutorial we set `PLINDER_ITERATION` to `tutorial`, to download
 only a small manageable excerpt of the entries.
 
+Using the `plinder` package:
+```bash
+pip install plinder
+# adding --yes will skip all confirmation prompts
+plinder_download --release 2024-06 --iteration tutorial --yes
+```
+
+Using `gsutil`:
 ```console
 $ export PLINDER_RELEASE=2024-06
 $ export PLINDER_ITERATION=tutorial
@@ -24,13 +37,6 @@ $ mkdir -p ~/.local/share/plinder/${PLINDER_RELEASE}/${PLINDER_ITERATION}/
 $ gsutil -m cp -r "gs://plinder/${PLINDER_RELEASE}/${PLINDER_ITERATION}/*" ~/.local/share/plinder/${PLINDER_RELEASE}/${PLINDER_ITERATION}/
 ```
 
-Alternatively, you can download (and unpack) the tutorial dataset with:
-
-```bash
-pip install plinder
-# adding --yes will skip all confirmation prompts
-plinder_download --release 2024-06 --iteration tutorial --yes
-```
 The full dataset (`PLINDER_ITERATION=v2`) has a size of hundreds of GB, so you are
 advised to have sufficient space for usage of the production dataset.
 

--- a/docs/tutorial/dataset.md
+++ b/docs/tutorial/dataset.md
@@ -24,6 +24,12 @@ $ mkdir -p ~/.local/share/plinder/${PLINDER_RELEASE}/${PLINDER_ITERATION}/
 $ gsutil -m cp -r "gs://plinder/${PLINDER_RELEASE}/${PLINDER_ITERATION}/*" ~/.local/share/plinder/${PLINDER_RELEASE}/${PLINDER_ITERATION}/
 ```
 
+Alternatively, you can download (and unpack) the tutorial dataset with:
+
+```bash
+pip install plinder
+plinder_download --release 2024-06 --iteration tutorial
+```
 The full dataset (`PLINDER_ITERATION=v2`) has a size of hundreds of GB, so you are
 advised to have sufficient space for usage of the production dataset.
 
@@ -75,8 +81,8 @@ The structure files can be found in the subfolder
 To unpack the structures run
 
 ```bash
-cd ~/.local/share/plinder/${PLINDER_RELEASE}/${PLINDER_ITERATION}/systems; for i in ls *zip; do unzip $i; touch $(i//.zip//)_done; done
-cd ~/.local/share/plinder/${PLINDER_RELEASE}/${PLINDER_ITERATION}/linked_structures; for i in ls *zip; do unzip $i; touch $(i//.zip//)_done; done
+cd ~/.local/share/plinder/${PLINDER_RELEASE}/${PLINDER_ITERATION}/systems; for i in `ls *zip`; do unzip $i; touch ${i//.zip/}_done; done
+cd ~/.local/share/plinder/${PLINDER_RELEASE}/${PLINDER_ITERATION}/linked_structures; for i in `ls *zip`; do unzip $i; touch ${i//.zip/}_done; done
 ```
 
 This will yield directories such as `7eek__1__1.A__1.I`, which is what we call a PLINDER

--- a/docs/tutorial/dataset.md
+++ b/docs/tutorial/dataset.md
@@ -75,7 +75,8 @@ The structure files can be found in the subfolder
 To unpack the structures run
 
 ```bash
-cd ~/.local/share/plinder/${PLINDER_RELEASE}/${PLINDER_ITERATION}/systems; for i in ls *zip; do unzip $i; done
+cd ~/.local/share/plinder/${PLINDER_RELEASE}/${PLINDER_ITERATION}/systems; for i in ls *zip; do unzip $i; touch $(i//.zip//)_done; done
+cd ~/.local/share/plinder/${PLINDER_RELEASE}/${PLINDER_ITERATION}/linked_structures; for i in ls *zip; do unzip $i; touch $(i//.zip//)_done; done
 ```
 
 This will yield directories such as `7eek__1__1.A__1.I`, which is what we call a PLINDER

--- a/docs/tutorial/dataset.md
+++ b/docs/tutorial/dataset.md
@@ -28,7 +28,8 @@ Alternatively, you can download (and unpack) the tutorial dataset with:
 
 ```bash
 pip install plinder
-plinder_download --release 2024-06 --iteration tutorial
+# adding --yes will skip all confirmation prompts
+plinder_download --release 2024-06 --iteration tutorial --yes
 ```
 The full dataset (`PLINDER_ITERATION=v2`) has a size of hundreds of GB, so you are
 advised to have sufficient space for usage of the production dataset.
@@ -82,7 +83,6 @@ To unpack the structures run
 
 ```bash
 cd ~/.local/share/plinder/${PLINDER_RELEASE}/${PLINDER_ITERATION}/systems; for i in `ls *zip`; do unzip $i; touch ${i//.zip/}_done; done
-cd ~/.local/share/plinder/${PLINDER_RELEASE}/${PLINDER_ITERATION}/linked_structures; for i in `ls *zip`; do unzip $i; touch ${i//.zip/}_done; done
 ```
 
 This will yield directories such as `7eek__1__1.A__1.I`, which is what we call a PLINDER

--- a/src/plinder/core/index/utils.py
+++ b/src/plinder/core/index/utils.py
@@ -163,7 +163,7 @@ def load_entries(
     return reduced
 
 
-def download_plinder_cmd() -> None:
+def download_plinder_cmd(args: list[str] | None = None) -> None:
     """
     Download the full plinder dataset for the current configuration.
     Note that even though this is wrapped in a progress bar, the estimated
@@ -175,7 +175,7 @@ def download_plinder_cmd() -> None:
     parser.add_argument("--release", default=None, help="plinder release")
     parser.add_argument("--iteration", default=None, help="plinder iteration")
     parser.add_argument("-y", "--yes", action="store_true", help="skip confirmation")
-    ns, args = parser.parse_known_args()
+    ns, args = parser.parse_known_args(args=args)
     autodo = ns.yes
     if len(args):
         LOG.warning(f"ignoring arguments {args}")
@@ -209,7 +209,10 @@ def download_plinder_cmd() -> None:
         path = None
         if attr == "scores":
             do = (
-                input("Download the full scores dataset? [Y/n] ").lower() in ["", "y", "yes"] if not autodo else True
+                input("Download the full scores dataset? [Y/n] ").lower()
+                in ["", "y", "yes"]
+                if not autodo
+                else True
             )
             if do:
                 for subdb in ["apo", "pred", "holo"]:

--- a/src/plinder/core/index/utils.py
+++ b/src/plinder/core/index/utils.py
@@ -22,10 +22,7 @@ _MANIFEST = None
 
 
 @timeit
-def get_plindex(
-    *,
-    cfg: Optional[DictConfig] = None,
-) -> pd.DataFrame:
+def get_plindex() -> pd.DataFrame:
     """
     Fetch the plindex and cache it
 
@@ -39,22 +36,17 @@ def get_plindex(
     pd.DataFrame
         the plindex
     """
+    from plinder.core.scores import query_index
+
     global _PLINDEX
 
     if _PLINDEX is not None:
         return _PLINDEX
-    cfg = cfg or get_config()
-    suffix = f"{cfg.data.index}/{cfg.data.index_file}"
-    index = cpl.get_plinder_path(rel=suffix)
-    LOG.info(f"reading {index}")
-    _PLINDEX = pd.read_parquet(index)
+    _PLINDEX = query_index(columns=["*"])
     return _PLINDEX
 
 
-def get_manifest(
-    *,
-    cfg: Optional[DictConfig] = None,
-) -> pd.DataFrame:
+def get_manifest() -> pd.DataFrame:
     """
     Fetch the manifest and cache it
 
@@ -70,19 +62,15 @@ def get_manifest(
     pd.DataFrame
         the manifest
     """
+    from plinder.core.scores import query_index
+
     global _MANIFEST
 
     if _MANIFEST is not None:
         return _MANIFEST
-    cfg = cfg or get_config()
-    suffix = f"{cfg.data.manifest}/{cfg.data.manifest_file}"
-    manifest = Path(f"{cfg.data.plinder_dir}/{suffix}")
-    if not manifest.exists() or cfg.data.force_update:
-        manifest.parent.mkdir(exist_ok=True, parents=True)
-        plindex = get_plindex(cfg=cfg)
-        plindex[["system_id", "entry_pdb_id"]].to_parquet(manifest, index=False)
-    _MANIFEST = pd.read_parquet(manifest)
+    _MANIFEST = query_index(columns=["system_id", "entry_pdb_id"])
     return _MANIFEST
+
 
 
 def _prune_entry(entry: dict[str, Any]) -> dict[str, Any]:

--- a/src/plinder/core/index/utils.py
+++ b/src/plinder/core/index/utils.py
@@ -173,7 +173,7 @@ def download_plinder_cmd() -> None:
     LOG.info(
         dedent(
             f"""
-            Downloading {cfg.data.plinder_remote} -> {cfg.data.plinder_dir}.
+            Syncing {cfg.data.plinder_remote} -> {cfg.data.plinder_dir}.
             If this is the first time you are running this command, it will take a while!
 
             The estimated time on the progress bar may vary wildly based on varied file sizes.
@@ -191,7 +191,7 @@ def download_plinder_cmd() -> None:
             do = input("Download the full scores dataset? [Y/n] ")
             if do.lower() in ["", "y", "yes"]:
                 for subdb in ["apo", "pred", "holo"]:
-                    LOG.info(f"downloading {getattr(cfg.data, attr)}/search_db={subdb}, this may take a while!")
+                    LOG.info(f"Syncing {getattr(cfg.data, attr)}/search_db={subdb}, this may take a while!")
                     if subdb == "holo":
                         LOG.info("the tqdm progress bar for holo is not very useful, please be patient!")
                     cpl.get_plinder_path(
@@ -201,7 +201,7 @@ def download_plinder_cmd() -> None:
             else:
                 LOG.info("skipping scores download, plinder.core.scores will download it lazily on request!")
         else:
-            msg = f"downloading {getattr(cfg.data, attr)}"
+            msg = f"Syncing {getattr(cfg.data, attr)}"
             do = True
             if attr in ["linked_structures", "systems"]:
                 do = input("Download the linked_structures dataset? [Y/n] ").lower() in ["", "y", "yes"]
@@ -215,6 +215,6 @@ def download_plinder_cmd() -> None:
             else:
                 LOG.info(f"skipping {attr} download, plinder.core.PlinderSystem will download lazily as needed on request!")
         if path is not None and attr in ["linked_structures", "systems"]:
-            LOG.info(f"extracting {getattr(cfg.data, attr)} archives")
+            LOG.info(f"extracting {getattr(cfg.data, attr)} archives, you may want to stretch your legs.")
             codes = [p.stem for p in path.glob("*zip")]
             get_zips_to_unpack(kind=attr, two_char_codes=codes)

--- a/src/plinder/core/index/utils.py
+++ b/src/plinder/core/index/utils.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from textwrap import dedent
 from json import load
 from pathlib import Path
+from textwrap import dedent
 from time import time
 from typing import Any, Optional
 from zipfile import ZipFile
@@ -74,7 +74,6 @@ def get_manifest() -> pd.DataFrame:
         return _MANIFEST
     _MANIFEST = query_index(columns=["system_id", "entry_pdb_id"])
     return _MANIFEST
-
 
 
 def _prune_entry(entry: dict[str, Any]) -> dict[str, Any]:
@@ -201,31 +200,45 @@ def download_plinder_cmd() -> None:
         )
     )
     for attr in cfg.data:
-        if attr.startswith("plinder_") or attr.endswith("_file") or attr in ["ingest", "validation", "force_update"]:
+        if (
+            attr.startswith("plinder_")
+            or attr.endswith("_file")
+            or attr in ["ingest", "validation", "force_update"]
+        ):
             continue
         path = None
         if attr == "scores":
-            do = input("Download the full scores dataset? [Y/n] ") if not autodo else "y"
-            if do.lower() in ["", "y", "yes"]:
+            do = (
+                input("Download the full scores dataset? [Y/n] ").lower() in ["", "y", "yes"] if not autodo else True
+            )
+            if do:
                 for subdb in ["apo", "pred", "holo"]:
                     msg = f"Syncing {getattr(cfg.data, attr)}/search_db={subdb}"
                     if subdb == "holo":
                         msg += ", this may take a while!"
                     LOG.info(msg)
                     if subdb == "holo":
-                        LOG.info("Note that the tqdm progress bar for holo is not very useful, please be patient!")
+                        LOG.info(
+                            "Note that the tqdm progress bar for holo is not very useful, please be patient!"
+                        )
                     cpl.get_plinder_path(
                         rel=f"{getattr(cfg.data, attr)}/search_db={subdb}",
                         force_progress=True,
                     )
             else:
-                LOG.info("skipping scores download, plinder.core.scores will download it lazily on request!")
+                LOG.info(
+                    "skipping scores download, plinder.core.scores will download it lazily on request!"
+                )
         else:
             msg = f"Syncing {getattr(cfg.data, attr)}"
             do = True
             if attr in ["linked_structures", "systems"]:
                 if not autodo:
-                    do = input(f"Download the {attr} dataset? [Y/n] ").lower() in ["", "y", "yes"]
+                    do = input(f"Download the {attr} dataset? [Y/n] ").lower() in [
+                        "",
+                        "y",
+                        "yes",
+                    ]
                 else:
                     do = True
                 msg += ", this may take a while!"
@@ -236,9 +249,13 @@ def download_plinder_cmd() -> None:
                     force_progress=True,
                 )
             else:
-                LOG.info(f"skipping {attr} download, plinder.core.PlinderSystem will download lazily as needed on request!")
+                LOG.info(
+                    f"skipping {attr} download, plinder.core.PlinderSystem will download lazily as needed on request!"
+                )
         if path is not None and attr in ["linked_structures", "systems"]:
-            LOG.info(f"extracting {getattr(cfg.data, attr)} archives, you may want to stretch your legs.")
+            LOG.info(
+                f"extracting {getattr(cfg.data, attr)} archives, you may want to stretch your legs."
+            )
             codes = [p.stem for p in path.glob("*zip")]
             get_zips_to_unpack(kind=attr, two_char_codes=codes)
 

--- a/src/plinder/core/index/utils.py
+++ b/src/plinder/core/index/utils.py
@@ -207,7 +207,7 @@ def download_plinder_cmd() -> None:
             msg = f"Syncing {getattr(cfg.data, attr)}"
             do = True
             if attr in ["linked_structures", "systems"]:
-                do = input("Download the linked_structures dataset? [Y/n] ").lower() in ["", "y", "yes"]
+                do = input(f"Download the {attr} dataset? [Y/n] ").lower() in ["", "y", "yes"]
                 msg += ", this may take a while!"
             if do:
                 LOG.info(msg)

--- a/src/plinder/core/index/utils.py
+++ b/src/plinder/core/index/utils.py
@@ -2,6 +2,7 @@
 # Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
+from argparse import ArgumentParser
 from textwrap import dedent
 from json import load
 from pathlib import Path
@@ -169,6 +170,10 @@ def download_plinder_cmd() -> None:
     completion time can vary wildly as it iterates over larger files vs.
     smaller ones.
     """
+    _, args = ArgumentParser(usage=download_plinder_cmd.__doc__).parse_known_args()
+    if len(args):
+        LOG.warning(f"ignoring arguments {args}")
+
     cfg = get_config()
     LOG.info(
         dedent(
@@ -182,9 +187,7 @@ def download_plinder_cmd() -> None:
         )
     )
     for attr in cfg.data:
-        if attr.startswith("plinder_") or attr.endswith("_file"):
-            continue
-        if attr in ["validation"]:
+        if attr.startswith("plinder_") or attr.endswith("_file") or attr in ["validation", "force_update"]:
             continue
         path = None
         if attr == "scores":

--- a/src/plinder/core/loader/loader.py
+++ b/src/plinder/core/loader/loader.py
@@ -9,6 +9,7 @@ import pandas as pd
 from torch.utils.data import Dataset
 
 from plinder.core.split.utils import get_split
+from plinder.core.scores.links import query_links
 from plinder.core.system import system
 
 
@@ -49,7 +50,9 @@ class PlinderDataset(Dataset):  # type: ignore
         self._system_ids = df.loc[df["split"] == split, "system_id"].to_list()
         self._num_examples = len(self._system_ids)
         self._store_file_path = store_file_path
-        self.load_alternative_structures = load_alternative_structures
+        self._links = None
+        if load_alternative_structures:
+            self._links = query_links().groupby("reference_system_id")
         self.num_alternative_structures = num_alternative_structures
 
     def __len__(self) -> int:
@@ -72,13 +75,11 @@ class PlinderDataset(Dataset):  # type: ignore
         if self._store_file_path:
             item["path"] = s.system_cif
 
-        if self.load_alternative_structures:
-            if s.linked_structures is not None and not s.linked_structures.empty:
-                links = s.linked_structures.groupby("kind")
-                for kind, group in links:
-                    for link_id in group["id"].values[
-                        : self.num_alternative_structures
-                    ]:
+        if self._links is not None:
+            links = self._links.get_group(s.system_id)
+            if not links.empty:
+                alts = links.groupby("kind").head(self.num_alternative_structures)
+                for kind, link_id in zip(alts["kind"], alts["id"]):
                         structure = s.get_linked_structure(
                             link_kind=str(kind), link_id=link_id
                         )

--- a/src/plinder/core/loader/loader.py
+++ b/src/plinder/core/loader/loader.py
@@ -8,8 +8,8 @@ import atom3d.util.formats as fo
 import pandas as pd
 from torch.utils.data import Dataset
 
-from plinder.core.split.utils import get_split
 from plinder.core.scores.links import query_links
+from plinder.core.split.utils import get_split
 from plinder.core.system import system
 
 
@@ -80,14 +80,14 @@ class PlinderDataset(Dataset):  # type: ignore
             if not links.empty:
                 alts = links.groupby("kind").head(self.num_alternative_structures)
                 for kind, link_id in zip(alts["kind"], alts["id"]):
-                        structure = s.get_linked_structure(
-                            link_kind=str(kind), link_id=link_id
-                        )
+                    structure = s.get_linked_structure(
+                        link_kind=str(kind), link_id=link_id
+                    )
+                    item["alternative_structures"][
+                        f"{kind}_{link_id}_df"
+                    ] = fo.bp_to_df(fo.read_any(structure))
+                    if self._store_file_path:
                         item["alternative_structures"][
-                            f"{kind}_{link_id}_df"
-                        ] = fo.bp_to_df(fo.read_any(structure))
-                        if self._store_file_path:
-                            item["alternative_structures"][
-                                f"{kind}_{link_id}_path"
-                            ] = structure
+                            f"{kind}_{link_id}_path"
+                        ] = structure
         return item

--- a/src/plinder/core/split/utils.py
+++ b/src/plinder/core/split/utils.py
@@ -101,7 +101,7 @@ def get_extended_plindex(
     plindex: Optional[pd.DataFrame] = None,
 ) -> pd.DataFrame:
     if plindex is None:
-        plindex = get_plindex(cfg=cfg)
+        plindex = get_plindex()
     plindex = reset_lipinski_and_other(plindex)
     plindex["system_ligand_max_qed"] = plindex.groupby("system_id")[
         "ligand_qed"

--- a/src/plinder/core/system/system.py
+++ b/src/plinder/core/system/system.py
@@ -97,8 +97,10 @@ class PlinderSystem:
             self._archive = archive.parent / self.system_id  # type: ignore
             assert self._archive is not None
             if not self._archive.is_dir():
-                with ZipFile(archive) as arch:
-                    arch.extractall(path=archive.parent)
+                assert self.entry is not None
+                if len(self.entry['systems']):
+                    with ZipFile(archive) as arch:
+                        arch.extractall(path=archive.parent)
         return self._archive
 
     @property

--- a/src/plinder/core/system/system.py
+++ b/src/plinder/core/system/system.py
@@ -94,17 +94,9 @@ class PlinderSystem:
         if self._archive is None:
             zips = get_zips_to_unpack(kind="systems", system_ids=[self.system_id])
             [archive] = list(zips.keys())
-            _archive = archive.parent / self.system_id
-            if not _archive.is_dir():
-                assert self.entry is not None
-                if len(self.entry['systems']):
-                    try:
-                        with ZipFile(archive) as arch:
-                            arch.extractall(path=archive.parent)
-                    except BadZipFile:
-                        archive.unlink()
-                        return self.archive
-            self._archive = _archive
+            self._archive = archive.parent / self.system_id
+            if not self._archive.is_dir():
+                raise ValueError(f"system_id={self.system_id} not found in systems")
         return self._archive
 
     @property
@@ -254,13 +246,6 @@ class PlinderSystem:
             )
             [archive] = list(zips.keys())
             self._linked_archive = archive.parent
-            if not (self._linked_archive / "apo" / self.system_id).is_dir() or not (
-                self._linked_archive / "pred" / self.system_id
-            ).is_dir():
-                assert self.entry is not None
-                if len(self.entry['systems']):
-                    with ZipFile(archive) as arch:
-                        arch.extractall(path=archive.parent)
         return self._linked_archive
 
     def get_linked_structure(self, link_kind: str, link_id: str) -> str:

--- a/src/plinder/core/system/system.py
+++ b/src/plinder/core/system/system.py
@@ -244,8 +244,10 @@ class PlinderSystem:
                 if not (self._linked_archive / "apo" / self.system_id).is_dir() or not (
                     self._linked_archive / "pred" / self.system_id
                 ).is_dir():
-                    with ZipFile(archive) as arch:
-                        arch.extractall(path=archive.parent)
+                    assert self.entry is not None
+                    if len(self.entry['systems']):
+                        with ZipFile(archive) as arch:
+                            arch.extractall(path=archive.parent)
         return self._linked_structures
 
     @property

--- a/src/plinder/core/system/system.py
+++ b/src/plinder/core/system/system.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
-from zipfile import BadZipFile, ZipFile
 
 import pandas as pd
 
@@ -34,14 +33,14 @@ class PlinderSystem:
         system_id: str,
         prune: bool = True,
     ) -> None:
-        self.system_id = system_id
-        self.prune = prune
-        self._entry = None
-        self._system = None
-        self._archive = None
-        self._chain_mapping = None
-        self._water_mapping = None
-        self._linked_structures = None
+        self.system_id: str = system_id
+        self.prune: bool = prune
+        self._entry: dict[str, Any] | None = None
+        self._system: dict[str, Any] | None = None
+        self._archive: Path | None = None
+        self._chain_mapping: dict[str, Any] | None = None
+        self._water_mapping: dict[str, Any] | None = None
+        self._linked_structures: pd.DataFrame | None = None
         self._linked_archive: Path | None = None
 
     @property

--- a/src/plinder/core/system/utils.py
+++ b/src/plinder/core/system/utils.py
@@ -21,7 +21,7 @@ def load_systems(
     )
     if kind == "system_ids":
         return {system_id: PlinderSystem(system_id=system_id) for system_id in items}
-    manifest = get_manifest(cfg=cfg)
+    manifest = get_manifest()
     systems = {}
     if kind == "pdb_ids":
         for pdb_id in items:

--- a/src/plinder/core/utils/config.py
+++ b/src/plinder/core/utils/config.py
@@ -242,7 +242,6 @@ class DataConfig:
     fingerprints: str = "fingerprints"
     fingerprint_file: str = "ligands_per_system.parquet"
     index: str = "index"
-    manifest: str = "manifest"
     ligand_scores: str = "ligand_scores"
     ligands: str = "ligands"
     links: str = "links"
@@ -253,7 +252,6 @@ class DataConfig:
     split_file: str = "split.parquet"
     systems: str = "systems"
     index_file: str = "annotation_table.parquet"
-    manifest_file: str = "manifest.parquet"
     force_update: bool = False
 
     def __post_init__(self) -> None:

--- a/src/plinder/core/utils/cpl.py
+++ b/src/plinder/core/utils/cpl.py
@@ -114,7 +114,9 @@ def _get_fsroot(cfg: DictConfig) -> str:
     return str(root)
 
 
-def get_plinder_path(*, rel: str = "", download: bool = True, force_progress: bool = False) -> Path:
+def get_plinder_path(
+    *, rel: str = "", download: bool = True, force_progress: bool = False
+) -> Path:
     """
     Get a cloudpathlib path to a file or directory in the plinder bucket.
     This provides a convenient way to manage local file caching since it

--- a/src/plinder/core/utils/cpl.py
+++ b/src/plinder/core/utils/cpl.py
@@ -58,7 +58,7 @@ def retry(
     return _retry_decorator(retries)(f)
 
 
-def thread_pool(func: Callable[..., T], iter: Iterable[T]) -> None:
+def thread_pool(func: Callable[..., None], iter: Iterable[T]) -> None:
     with ThreadPoolExecutor() as executor:
         futures = [executor.submit(func, item) for item in iter]
         wait(futures, return_when=ALL_COMPLETED)

--- a/src/plinder/core/utils/unpack.py
+++ b/src/plinder/core/utils/unpack.py
@@ -8,6 +8,7 @@ from typing import Literal, Optional
 from zipfile import BadZipFile, ZipFile
 
 from omegaconf import DictConfig
+from tqdm.contrib.concurrent import thread_map
 
 from plinder.core.utils import cpl
 from plinder.core.utils.config import get_config
@@ -139,7 +140,7 @@ def get_zips_to_unpack(
 
     if kind in ["systems", "linked_structures"]:
         if len(paths) > 10:
-            cpl.thread_map(_unpack_zip, paths)
+            thread_map(_unpack_zip, paths)
         else:
             cpl.thread_pool(_unpack_zip, paths)
 

--- a/src/plinder/core/utils/unpack.py
+++ b/src/plinder/core/utils/unpack.py
@@ -2,16 +2,16 @@
 # Distributed under the terms of the Apache License 2.0
 from __future__ import annotations
 
-from time import time
 from pathlib import Path
+from time import time
 from typing import Literal, Optional
 from zipfile import BadZipFile, ZipFile
 
 from omegaconf import DictConfig
 
 from plinder.core.utils import cpl
-from plinder.core.utils.log import setup_logger
 from plinder.core.utils.config import get_config
+from plinder.core.utils.log import setup_logger
 
 LOG = setup_logger(__name__)
 ZIP_KINDS = Literal["entries", "linked_structures", "systems"]
@@ -61,6 +61,7 @@ def _unpack_zip(path: Path) -> None:
         arch.extractall(path=path.parent)
         done.touch()
     LOG.info(f"validating and extracting {path} took {time() - t0:.2f}s")
+    return
 
 
 def get_zips_to_unpack(

--- a/tests/core/test_index_utils.py
+++ b/tests/core/test_index_utils.py
@@ -49,8 +49,17 @@ def test_load_entries(mock_cpl):
     assert len(blob) == 1
 
 
-def test_download_cmd(mock_cpl):
-    utils.download_plinder_cmd()
+@pytest.mark.parametrize(
+    "args",
+    [
+        [],
+        ["--release", "2024-04"],
+        ["--iteration", "v1"],
+        ["--release", "2024-06", "--iteration", "v2"]
+    ]
+)
+def test_download_cmd(args, mock_cpl):
+    utils.download_plinder_cmd(args=args + ["-y"])
 
 
 def test_get_extended_plindex(mock_cpl):

--- a/tests/core/test_index_utils.py
+++ b/tests/core/test_index_utils.py
@@ -8,7 +8,7 @@ from plinder.core.index import utils
 from plinder.core.split import utils as split_utils
 
 
-def mock_path(*, rel: str = "", download: bool = False):
+def mock_path(*, rel: str = "", download: bool = False, force_progress: bool = False):
     obj = Path(
         "/".join(
             [


### PR DESCRIPTION
Iterating over plinder systems identifies some inefficiencies which are not obvious when working in the low sample regime. This PR accomplishes the following:

- Push archive extraction logic into `unpack.get_zips_to_unpack` rather than inspecting the archive within the `PlinderSystem`
- `PlinderSystem` will assume extraction already occurred, but still evaluate lazily if necessary
- cache GSClients per unique configuration to save ~1s per `get_plinder_path` call
- Skip calling `query_links` for every `PlinderSystem` in the `PlinderDataset`
  - when `load_alternative_structures` is set, pre-load all apo/pred links and group them by system ID
- Improve the user experience for `plinder_download` to make it a viable alternative to `gsutil -m cp -r && cd && for i in ...; do unzip $i; done && ...`

With all of these changes, iterating over `PlinderSystems` and using the `PlinderDatset` becomes reasonable in terms of runtime performance. Things can be further expedited with the usage of the `PLINDER_OFFLINE=true` environment variable. 