### PR TITLE
Fix PyPI publish again

### DIFF
--- a/dockerfiles/main/Dockerfile
+++ b/dockerfiles/main/Dockerfile
@@ -5,10 +5,12 @@ ARG MAMBA_DOCKERFILE_ACTIVATE=1
 ARG DEPENDENCY_BLOCKS=test
 
 WORKDIR /app
+COPY requirements_data.txt requirements_data.txt
 COPY src src
 COPY pyproject.toml pyproject.toml
 RUN --mount=source=.git,target=.git,type=bind \
     --mount=type=secret,id=INDEX_URL \
+    python -m pip install -r requirements_data.txt && \
     PIP_KEYRING_PROVIDER=subprocess python -m pip install \
     --extra-index-url "$(cat /run/secrets/INDEX_URL)" \
     --no-cache-dir '.['"${DEPENDENCY_BLOCKS}"']'

--- a/docs/contribution/development.md
+++ b/docs/contribution/development.md
@@ -36,7 +36,7 @@ by a GitHub link directly, make a pip-installable package problematic. These add
 dependencies can be installed by running:
 
 ```console
-$ pip install plinder[data]
+$ pip install -r requirements_data.txt
 ```
 
 `plinder.eval` also relies on `openstructure` for metrics

--- a/flows/docker.py
+++ b/flows/docker.py
@@ -16,7 +16,7 @@ from proc import Proc
 
 logging.basicConfig(level=logging.INFO)
 LOG = logging.getLogger("doc")
-DEPENDENCY_BLOCKS = "data,test,pipeline,plots"
+DEPENDENCY_BLOCKS = "test,pipeline,plots"
 
 
 def get_dev_tag() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,11 +70,6 @@ type = [
 dev = [
     "plinder[lint,test,type]",
 ]
-data = [
-    "networkit >= 11.0",
-    "pdb-validation @ git+https://git.scicore.unibas.ch/schwede/ligand-validation.git",
-    "mmpdb @ git+https://github.com/rdkit/mmpdb.git",
-]
 loader = [
     "torch",
     "atom3d",

--- a/requirements_data.txt
+++ b/requirements_data.txt
@@ -1,0 +1,3 @@
+  networkit >= 11.0
+  pdb-validation @ git+https://git.scicore.unibas.ch/schwede/ligand-validation.git
+  mmpdb @ git+https://github.com/rdkit/mmpdb.git


### PR DESCRIPTION
Should have left the `requirements_data.txt` from #45 instead of trying to support an optional dependency block.