### PR TITLE
Fix linked scores

### DIFF
--- a/flows/data_ingest.py
+++ b/flows/data_ingest.py
@@ -12,7 +12,7 @@ from metaflow import FlowSpec, Parameter, kubernetes, environment, step, retry
 MOUNT = "/plinder"
 K8S = dict(
     cpu=1,
-    image="us-east1-docker.pkg.dev/vantai-analysis/metaflow/plinder:v0.2.0-4-g5ce56a60",
+    image="us-east1-docker.pkg.dev/vantai-analysis/metaflow/plinder:v0.2.1-45-g5fda6e4d",
     node_selector={
         "topology.kubernetes.io/zone": "us-east1-b",
     },
@@ -63,10 +63,10 @@ class PlinderDataIngestFlow(FlowSpec):
         self.pipeline = IngestPipeline(conf=get_config(config_contents=contents))
         # self.next(self.scatter_download_rcsb_files)
         # self.next(self.scatter_make_entries)
-        # self.next(self.scatter_structure_qc)
+        self.next(self.scatter_structure_qc)
         # self.next(self.scatter_collate_partitions)
         # self.next(self.scatter_make_components_and_communities)
-        self.next(self.scatter_make_links)
+        # self.next(self.scatter_make_links)
 
     # @kubernetes(**{**K8S, **LARGE_MEM, **{"cpu": 3.5, "memory": 175000}})
     # @environment(**ENV)
@@ -190,32 +190,32 @@ class PlinderDataIngestFlow(FlowSpec):
     #     self.pipeline.cfg.context.pdb_ids = self.original_pdb_ids
     #     self.next(self.scatter_structure_qc)
     #
-    # @kubernetes(**K8S)
-    # @environment(**ENV)
-    # @retry
-    # @step
-    # def scatter_structure_qc(self):
-    #     self.chunks = self.pipeline.scatter_structure_qc()
-    #     self.next(self.structure_qc, foreach="chunks")
-    #
-    # @kubernetes(**{**K8S, **{"memory": 4000}})
-    # @environment(**ENV)
-    # @retry
-    # @step
-    # def structure_qc(self):
-    #     self.pipeline.structure_qc(self.input)
-    #     self.next(self.join_structure_qc)
-    #
-    # @kubernetes(**K8S)
-    # @environment(**ENV)
-    # @retry
-    # @step
-    # def join_structure_qc(self, inputs):
-    #     self.pipeline = inputs[0].pipeline
-    #     self.merge_artifacts(inputs, exclude=["chunks"])
-    #     self.pipeline.join_structure_qc()
-    #     self.next(self.scatter_make_system_archives)
-    #
+    @kubernetes(**K8S)
+    @environment(**ENV)
+    @retry
+    @step
+    def scatter_structure_qc(self):
+        self.chunks = self.pipeline.scatter_structure_qc()
+        self.next(self.structure_qc, foreach="chunks")
+
+    @kubernetes(**{**K8S, **{"memory": 4000}})
+    @environment(**ENV)
+    @retry
+    @step
+    def structure_qc(self):
+        self.pipeline.structure_qc(self.input)
+        self.next(self.join_structure_qc)
+
+    @kubernetes(**K8S)
+    @environment(**ENV)
+    @retry
+    @step
+    def join_structure_qc(self, inputs):
+        self.pipeline = inputs[0].pipeline
+        self.merge_artifacts(inputs, exclude=["chunks"])
+        self.pipeline.join_structure_qc(inputs)
+        self.next(self.end) # self.scatter_make_system_archives)
+
     # @kubernetes(**K8S)
     # @environment(**ENV)
     # @retry
@@ -400,58 +400,58 @@ class PlinderDataIngestFlow(FlowSpec):
     #     self.pipeline.assign_apo_pred_systems()
     #     self.next(self.end)
 
-    @kubernetes(**K8S)
-    @environment(**ENV)
-    @retry
-    @step
-    def scatter_make_links(self):
-        self.chunks = self.pipeline.scatter_make_links()
-        self.next(self.make_links, foreach="chunks")
-
-    @kubernetes(**{**K8S, **DATABASES})
-    @environment(**ENV)
-    @retry
-    @step
-    def make_links(self):
-        self.pipeline.cfg.flow.make_links_cpu = DATABASES["cpu"] - 1
-        self.pipeline.make_links(self.input)
-        self.next(self.join_make_links)
-
-    @kubernetes(**K8S)
-    @environment(**ENV)
-    @retry
-    @step
-    def join_make_links(self, inputs):
-        self.pipeline = inputs[0].pipeline
-        self.merge_artifacts(inputs, exclude=["chunks"])
-        self.next(self.scatter_make_linked_structures)
-
-    @kubernetes(**{**K8S, **DATABASES})
-    @environment(**ENV)
-    @retry
-    @step
-    def scatter_make_linked_structures(self):
-        self.chunks = self.pipeline.scatter_make_linked_structures()
-        self.next(self.make_linked_structures, foreach="chunks")
-
-    @kubernetes(**{**K8S, **WORKSTATION})
-    @environment(**ENV)
-    @retry
-    @step
-    def make_linked_structures(self):
-        self.pipeline.cfg.flow.make_linked_structures_cpu = WORKSTATION["cpu"] - 1
-        self.pipeline.make_linked_structures(self.input)
-        self.next(self.join_make_linked_structures)
-
-    @kubernetes(**K8S)
-    @environment(**ENV)
-    @retry
-    @step
-    def join_make_linked_structures(self, inputs):
-        self.pipeline = inputs[0].pipeline
-        self.pipeline.join_make_linked_structures(inputs)
-        self.merge_artifacts(inputs, exclude=["chunks"])
-        self.next(self.end)
+    # @kubernetes(**K8S)
+    # @environment(**ENV)
+    # @retry
+    # @step
+    # def scatter_make_links(self):
+    #     self.chunks = self.pipeline.scatter_make_links()
+    #     self.next(self.make_links, foreach="chunks")
+    #
+    # @kubernetes(**{**K8S, **DATABASES})
+    # @environment(**ENV)
+    # @retry
+    # @step
+    # def make_links(self):
+    #     self.pipeline.cfg.flow.make_links_cpu = DATABASES["cpu"] - 1
+    #     self.pipeline.make_links(self.input)
+    #     self.next(self.join_make_links)
+    #
+    # @kubernetes(**K8S)
+    # @environment(**ENV)
+    # @retry
+    # @step
+    # def join_make_links(self, inputs):
+    #     self.pipeline = inputs[0].pipeline
+    #     self.merge_artifacts(inputs, exclude=["chunks"])
+    #     self.next(self.scatter_make_linked_structures)
+    #
+    # @kubernetes(**{**K8S, **DATABASES})
+    # @environment(**ENV)
+    # @retry
+    # @step
+    # def scatter_make_linked_structures(self):
+    #     self.chunks = self.pipeline.scatter_make_linked_structures()
+    #     self.next(self.make_linked_structures, foreach="chunks")
+    #
+    # @kubernetes(**{**K8S, **WORKSTATION})
+    # @environment(**ENV)
+    # @retry
+    # @step
+    # def make_linked_structures(self):
+    #     self.pipeline.cfg.flow.make_linked_structures_cpu = WORKSTATION["cpu"] - 1
+    #     self.pipeline.make_linked_structures(self.input)
+    #     self.next(self.join_make_linked_structures)
+    #
+    # @kubernetes(**K8S)
+    # @environment(**ENV)
+    # @retry
+    # @step
+    # def join_make_linked_structures(self, inputs):
+    #     self.pipeline = inputs[0].pipeline
+    #     self.pipeline.join_make_linked_structures(inputs)
+    #     self.merge_artifacts(inputs, exclude=["chunks"])
+    #     self.next(self.end)
 
     @kubernetes(**K8S)
     @environment(**ENV)

--- a/flows/data_ingest.py
+++ b/flows/data_ingest.py
@@ -12,7 +12,7 @@ from metaflow import FlowSpec, Parameter, kubernetes, environment, step, retry
 MOUNT = "/plinder"
 K8S = dict(
     cpu=1,
-    image="us-east1-docker.pkg.dev/vantai-analysis/metaflow/plinder:v0.1.4-2-ge3663ef5",
+    image="us-east1-docker.pkg.dev/vantai-analysis/metaflow/plinder:v0.2.0-4-g5ce56a60",
     node_selector={
         "topology.kubernetes.io/zone": "us-east1-b",
     },
@@ -415,7 +415,7 @@ class PlinderDataIngestFlow(FlowSpec):
     def make_links(self):
         self.pipeline.cfg.flow.make_links_cpu = DATABASES["cpu"] - 1
         self.pipeline.make_links(self.input)
-        self.next(self.join_make_batch_scores)
+        self.next(self.join_make_links)
 
     @kubernetes(**K8S)
     @environment(**ENV)
@@ -432,7 +432,7 @@ class PlinderDataIngestFlow(FlowSpec):
     @step
     def scatter_make_linked_structures(self):
         self.chunks = self.pipeline.scatter_make_linked_structures()
-        self.next(self.make_links, foreach="chunks")
+        self.next(self.make_linked_structures, foreach="chunks")
 
     @kubernetes(**{**K8S, **WORKSTATION})
     @environment(**ENV)

--- a/flows/docker.py
+++ b/flows/docker.py
@@ -375,6 +375,7 @@ def main(argv: Optional[List[str]] = None):
     run = subs.add_parser("run", help="Run the app image")
     run.add_argument("--it", default=False, action="store_true", help="Run in interactive mode")
     run.add_argument("--script", default="", help="Script to run")
+    run.add_argument("--dirty", default=False, action="store_true", help="Mount current working tree")
     for sub in [build, test, run]:
         sub.add_argument(
             "--tag", default=None, help="The image tag to pass to build_image",

--- a/src/plinder/data/pipeline/config.py
+++ b/src/plinder/data/pipeline/config.py
@@ -114,9 +114,7 @@ class FlowConfig:
                 stage for stage in self.skip_specific_stages.split(",") if stage
             ]
         if isinstance(self.sub_databases, str):
-            self.sub_databases = [
-                db for db in self.sub_databases.split(",") if db
-            ]
+            self.sub_databases = [db for db in self.sub_databases.split(",") if db]
 
 
 @dataclass

--- a/src/plinder/data/pipeline/config.py
+++ b/src/plinder/data/pipeline/config.py
@@ -99,6 +99,7 @@ class FlowConfig:
     make_linked_structures_cpu: int = 8
     make_linked_structures_batch_size: int = 100
     make_linked_structures_force_update: bool = False
+    sub_databases: Any = "apo,pred"
 
     split_config_dir: str = ""
     test_leakage: bool = False
@@ -111,6 +112,10 @@ class FlowConfig:
         if isinstance(self.skip_specific_stages, str):
             self.skip_specific_stages = [
                 stage for stage in self.skip_specific_stages.split(",") if stage
+            ]
+        if isinstance(self.sub_databases, str):
+            self.sub_databases = [
+                db for db in self.sub_databases.split(",") if db
             ]
 
 

--- a/src/plinder/data/pipeline/config.py
+++ b/src/plinder/data/pipeline/config.py
@@ -94,7 +94,11 @@ class FlowConfig:
     run_batch_searches_batch_size: int = 10050
     make_batch_scores_batch_size: int = 90
     make_batch_scores_force_update: bool = False
-    assign_apo_pred_systems_cpus: int = 8
+
+    make_links_cpu: int = 8
+    make_linked_structures_cpu: int = 8
+    make_linked_structures_batch_size: int = 100
+    make_linked_structures_force_update: bool = False
 
     split_config_dir: str = ""
     test_leakage: bool = False

--- a/src/plinder/data/pipeline/pipeline.py
+++ b/src/plinder/data/pipeline/pipeline.py
@@ -347,7 +347,8 @@ class IngestPipeline:
     @utils.ingest_flow_control
     def make_links(self, search_dbs: list[str]) -> None:
         tasks.make_links(
-            data_dir=self.plinder_dir, search_dbs=search_dbs,
+            data_dir=self.plinder_dir,
+            search_dbs=search_dbs,
         )
 
     @utils.ingest_flow_control
@@ -361,7 +362,10 @@ class IngestPipeline:
 
     @utils.ingest_flow_control
     def make_linked_structures(self, system_ids: list[tuple[str, str]]) -> None:
-        force_update = self.cfg.data.force_update or self.cfg.flow.make_linked_structures_force_update
+        force_update = (
+            self.cfg.data.force_update
+            or self.cfg.flow.make_linked_structures_force_update
+        )
         tasks.make_linked_structures(
             data_dir=self.plinder_dir,
             search_dbs=self.cfg.flow.sub_databases,

--- a/src/plinder/data/pipeline/pipeline.py
+++ b/src/plinder/data/pipeline/pipeline.py
@@ -354,17 +354,17 @@ class IngestPipeline:
     def scatter_make_linked_structures(self) -> list[list[tuple[str, str]]]:
         chunks: list[list[tuple[str, str]]] = tasks.scatter_make_linked_structures(
             data_dir=self.plinder_dir,
-            search_dbs=self.cfg.scorer.sub_databases,
+            search_dbs=self.cfg.flow.sub_databases,
             batch_size=self.cfg.flow.make_linked_structures_batch_size,
         )
         return chunks
 
     @utils.ingest_flow_control
-    def make_linked_structures(self, search_dbs: list[str], system_ids: list[tuple[str, str]]) -> None:
+    def make_linked_structures(self, system_ids: list[tuple[str, str]]) -> None:
         force_update = self.cfg.data.force_update or self.cfg.flow.make_linked_structures_force_update
         tasks.make_linked_structures(
             data_dir=self.plinder_dir,
-            search_dbs=search_dbs,
+            search_dbs=self.cfg.flow.sub_databases,
             system_ids=system_ids,
             cpu=self.cfg.flow.make_linked_structures_cpu,
             force_update=force_update,
@@ -372,7 +372,7 @@ class IngestPipeline:
         return
 
     @utils.ingest_flow_control
-    def join_linked_structures(self, outputs: list[None]) -> None:
+    def join_make_linked_structures(self, outputs: list[None]) -> None:
         utils.mp_pack_linked_structures(data_dir=self.plinder_dir)
         utils.consolidate_linked_scores(data_dir=self.plinder_dir)
 

--- a/src/plinder/data/pipeline/pipeline.py
+++ b/src/plinder/data/pipeline/pipeline.py
@@ -337,13 +337,44 @@ class IngestPipeline:
         )
 
     @utils.ingest_flow_control
-    def assign_apo_pred_systems(self) -> None:
-        tasks.assign_apo_pred_systems(
+    def scatter_make_links(self) -> list[list[str]]:
+        chunks: list[list[str]] = tasks.scatter_make_links(
             data_dir=self.plinder_dir,
-            # TODO: pass this and cpu in from config
-            cpu=self.cfg.flow.assign_apo_pred_systems_cpus,
             search_dbs=self.cfg.scorer.sub_databases,
         )
+        return chunks
+
+    @utils.ingest_flow_control
+    def make_links(self, search_dbs: list[str]) -> None:
+        tasks.make_links(
+            data_dir=self.plinder_dir, search_dbs=search_dbs,
+        )
+
+    @utils.ingest_flow_control
+    def scatter_make_linked_structures(self) -> list[list[tuple[str, str]]]:
+        chunks: list[list[tuple[str, str]]] = tasks.scatter_make_linked_structures(
+            data_dir=self.plinder_dir,
+            search_dbs=self.cfg.scorer.sub_databases,
+            batch_size=self.cfg.flow.make_linked_structures_batch_size,
+        )
+        return chunks
+
+    @utils.ingest_flow_control
+    def make_linked_structures(self, search_dbs: list[str], system_ids: list[tuple[str, str]]) -> None:
+        force_update = self.cfg.data.force_update or self.cfg.flow.make_linked_structures_force_update
+        tasks.make_linked_structures(
+            data_dir=self.plinder_dir,
+            search_dbs=search_dbs,
+            system_ids=system_ids,
+            cpu=self.cfg.flow.make_linked_structures_cpu,
+            force_update=force_update,
+        )
+        return
+
+    @utils.ingest_flow_control
+    def join_linked_structures(self, outputs: list[None]) -> None:
+        utils.mp_pack_linked_structures(data_dir=self.plinder_dir)
+        utils.consolidate_linked_scores(data_dir=self.plinder_dir)
 
     def run_stage(self, stage: str) -> None:
         """

--- a/src/plinder/data/pipeline/tasks.py
+++ b/src/plinder/data/pipeline/tasks.py
@@ -1041,9 +1041,16 @@ def scatter_make_linked_structures(
 ) -> list[list[tuple[str, str]]]:
     items = []
     for search_db in search_dbs:
-        links = pd.read_parquet(data_dir / "linked_staging" / f"{search_db}_links.parquet")
-        items.extend([(search_db, system_id) for system_id in sorted(links["reference_system_id"])])
-    return [items[pos:pos + batch_size] for pos in range(0, len(items), batch_size)]
+        links = pd.read_parquet(
+            data_dir / "linked_staging" / f"{search_db}_links.parquet"
+        )
+        items.extend(
+            [
+                (search_db, system_id)
+                for system_id in sorted(links["reference_system_id"])
+            ]
+        )
+    return [items[pos : pos + batch_size] for pos in range(0, len(items), batch_size)]
 
 
 def make_linked_structures(
@@ -1056,7 +1063,9 @@ def make_linked_structures(
 ) -> None:
     import multiprocessing
 
-    from plinder.data.save_linked_structures import system_save_and_score_representatives
+    from plinder.data.save_linked_structures import (
+        system_save_and_score_representatives,
+    )
 
     linked_structures = data_dir / "linked_staging"
     grouped = {
@@ -1080,6 +1089,8 @@ def make_linked_structures(
             system_save_and_score_representatives,
             [
                 (system, group, data_dir, search_db, linked_structures, force_update)
-                for (search_db, system), group in links.groupby(["kind", "reference_system_id"])
-            ]
+                for (search_db, system), group in links.groupby(
+                    ["kind", "reference_system_id"]
+                )
+            ],
         )

--- a/src/plinder/data/pipeline/utils.py
+++ b/src/plinder/data/pipeline/utils.py
@@ -11,7 +11,7 @@ from json import dumps, load
 from os import listdir
 from pathlib import Path
 from time import time
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Dict, Literal, Optional, TypeVar
 from zipfile import ZIP_DEFLATED, ZipFile
 
 import pandas as pd
@@ -610,7 +610,7 @@ def pack_linked_structures(data_dir: Path, code: str, structures: bool = True) -
         if True, make structure archives
     """
     (data_dir / "links").mkdir(exist_ok=True, parents=True)
-    mode = "w" if structures else "r"
+    mode: Literal["r", "w"] = "w" if structures else "r"
     with ZipFile(
         data_dir / "links" / f"{code}.zip", mode, compression=ZIP_DEFLATED
     ) as archive:

--- a/src/plinder/data/pipeline/utils.py
+++ b/src/plinder/data/pipeline/utils.py
@@ -595,7 +595,7 @@ def create_nonredundant_dataset(*, data_dir: Path) -> None:
     )
 
 
-def pack_linked_structures(data_dir: Path, code: str) -> None:
+def pack_linked_structures(data_dir: Path, code: str, structures: bool = True) -> None:
     """
     Pack generated linked structures into a zip file for a particular
     two character code.
@@ -606,10 +606,13 @@ def pack_linked_structures(data_dir: Path, code: str) -> None:
         plinder root dir
     code : str
         two character code
+    structures : bool, default=True
+        if True, make structure archives
     """
     (data_dir / "links").mkdir(exist_ok=True, parents=True)
+    mode = "w" if structures else "r"
     with ZipFile(
-        data_dir / "links" / f"{code}.zip", "w", compression=ZIP_DEFLATED
+        data_dir / "links" / f"{code}.zip", mode, compression=ZIP_DEFLATED
     ) as archive:
         for search_db in ["apo", "pred"]:
             jsons = []
@@ -626,13 +629,14 @@ def pack_linked_structures(data_dir: Path, code: str) -> None:
                             jsons.append(load(f))
                     except Exception:
                         pass
-                    try:
-                        archive.write(
-                            f"{link}/superposed.cif",
-                            f"{search_db}/{system_id}/{link_id}/superposed.cif",
-                        )
-                    except Exception:
-                        pass
+                    if structures:
+                        try:
+                            archive.write(
+                                f"{link}/superposed.cif",
+                                f"{search_db}/{system_id}/{link_id}/superposed.cif",
+                            )
+                        except Exception:
+                            pass
             df = pd.DataFrame(jsons).rename(
                 columns={"reference": "reference_system_id", "model": "id"}
             )

--- a/src/plinder/data/pipeline/utils.py
+++ b/src/plinder/data/pipeline/utils.py
@@ -613,7 +613,7 @@ def pack_linked_structures(data_dir: Path, code: str) -> None:
     ) as archive:
         for search_db in ["apo", "pred"]:
             jsons = []
-            root = data_dir / "linked_structures" / search_db
+            root = data_dir / "linked_staging" / search_db
             system_ids = [
                 system_id for system_id in listdir(root) if system_id[1:3] == code
             ]
@@ -675,11 +675,10 @@ def consolidate_linked_scores(*, data_dir: Path) -> None:
             if not df.empty:
                 dfs.append(df)
         ndf = pd.concat(dfs)
-        odf = pd.read_parquet(
-            data_dir / "linked_structures" / f"{search_db}_links.parquet"
-        )
+        odf = pd.read_parquet(data_dir / "linked_staging" / f"{search_db}_links.parquet")
         df = pd.merge(odf, ndf, on=["reference_system_id", "id"])
-        df.to_parquet(data_dir / "links" / f"{search_db}_links.parquet", index=False)
+        (data_dir / "links" / f"kind={search_db}").mkdir(exist_ok=True, parents=True)
+        df.to_parquet(data_dir / "links" / f"kind={search_db}" / "links.parquet", index=False)
 
 
 def rename_clusters(*, data_dir: Path) -> None:

--- a/src/plinder/data/pipeline/utils.py
+++ b/src/plinder/data/pipeline/utils.py
@@ -675,10 +675,14 @@ def consolidate_linked_scores(*, data_dir: Path) -> None:
             if not df.empty:
                 dfs.append(df)
         ndf = pd.concat(dfs)
-        odf = pd.read_parquet(data_dir / "linked_staging" / f"{search_db}_links.parquet")
+        odf = pd.read_parquet(
+            data_dir / "linked_staging" / f"{search_db}_links.parquet"
+        )
         df = pd.merge(odf, ndf, on=["reference_system_id", "id"])
         (data_dir / "links" / f"kind={search_db}").mkdir(exist_ok=True, parents=True)
-        df.to_parquet(data_dir / "links" / f"kind={search_db}" / "links.parquet", index=False)
+        df.to_parquet(
+            data_dir / "links" / f"kind={search_db}" / "links.parquet", index=False
+        )
 
 
 def rename_clusters(*, data_dir: Path) -> None:

--- a/src/plinder/data/save_linked_structures.py
+++ b/src/plinder/data/save_linked_structures.py
@@ -341,7 +341,7 @@ def system_save_and_score_representatives(
 ) -> None:
     try:
         reference_system = utils.ReferenceSystem.from_reference_system(
-            data_dir / "raw_entries" / system[1:3], system
+            data_dir / "raw_entries" / system[1:3] / system, system,
         )
     except Exception as e:
         LOG.error(

--- a/src/plinder/data/save_linked_structures.py
+++ b/src/plinder/data/save_linked_structures.py
@@ -256,9 +256,7 @@ def save_superposition(
     overwrite: bool = False,
 ) -> bool:
     if not overwrite and (save_folder / "superposed.cif").exists():
-        LOG.warning(
-            f"save_superposition: {save_folder / 'superposed.cif'} exists"
-        )
+        LOG.warning(f"save_superposition: {save_folder / 'superposed.cif'} exists")
         return True
     target_cif_file = get_cif_file(data_dir, search_db, link.id)
     if not target_cif_file.exists():
@@ -341,7 +339,8 @@ def system_save_and_score_representatives(
 ) -> None:
     try:
         reference_system = utils.ReferenceSystem.from_reference_system(
-            data_dir / "raw_entries" / system[1:3] / system, system,
+            data_dir / "raw_entries" / system[1:3] / system,
+            system,
         )
     except Exception as e:
         LOG.error(

--- a/src/plinder/data/save_linked_structures.py
+++ b/src/plinder/data/save_linked_structures.py
@@ -295,6 +295,7 @@ def system_save_and_score_representative(
             reference_system,
             score_protein=True,
             score_posebusters=True,
+            rigid=False,
         ).summarize_scores()
         with open(save_folder / "scores.json", "w") as f:
             json.dump(scores, f)

--- a/src/plinder/eval/docking/utils.py
+++ b/src/plinder/eval/docking/utils.py
@@ -96,7 +96,7 @@ class ModelScores:
     score_posebusters: bool = False
     posebusters_mapper: str = "scrmsd"
     ligand_scores: list[LigandScores] | None = None
-    rigid: bool = True
+    rigid: bool = False
     score_protein: bool = False
     num_mapped_reference_proteins: int = 0
     num_mapped_proteins: int = 0
@@ -109,7 +109,7 @@ class ModelScores:
         model_file: Path,
         model_ligand_sdf_files: list[str | Path],
         reference: ReferenceSystem,
-        rigid: bool = True,
+        rigid: bool = False,
         score_protein: bool = False,
         score_posebusters: bool = False,
     ) -> "ModelScores":
@@ -272,7 +272,7 @@ class ModelScores:
                             self.posebusters_mapper
                         ].sdf_file,
                         mol_cond=self.reference.receptor_pdb_file,
-                        full_report=False,
+                        full_report=True,
                     ).to_dict()
                     key = (str(ligand_class.sdf_file), chain_name.split("_")[-1])
                     try:

--- a/src/plinder/eval/docking/utils.py
+++ b/src/plinder/eval/docking/utils.py
@@ -46,13 +46,13 @@ class ReferenceSystem:
     def from_reference_system(
         cls, system_dir: Path, reference_system: str
     ) -> "ReferenceSystem":
-        cif_file = system_dir / reference_system / "receptor.cif"
-        pdb_file = system_dir / reference_system / "receptor.pdb"
+        cif_file = system_dir / "receptor.cif"
+        pdb_file = system_dir / "receptor.pdb"
         entity = io.LoadMMCIF(cif_file.as_posix())
         ligand_sdf_files = {}
         ligands = []
         for chain in reference_system.split("__")[-1].split("_"):
-            sdf_file = system_dir / reference_system / "ligand_files" / f"{chain}.sdf"
+            sdf_file = system_dir / "ligand_files" / f"{chain}.sdf"
             ligand_sdf_files[chain] = sdf_file
             ligands.append(
                 io.LoadEntity(sdf_file.as_posix(), format="sdf").Select("ele != H")

--- a/src/plinder/eval/docking/write_scores.py
+++ b/src/plinder/eval/docking/write_scores.py
@@ -42,7 +42,7 @@ def write_scores_as_json(
             LOG.warning(f"get_scores: {output_file} exists")
             return
         reference_system = utils.ReferenceSystem.from_reference_system(
-            system_dir, scorer_input.reference_system_id
+            system_dir / scorer_input.reference_system_id, scorer_input.reference_system_id
         )
         receptor_file = scorer_input.receptor_file
         if np.isnan(receptor_file):

--- a/src/plinder/eval/docking/write_scores.py
+++ b/src/plinder/eval/docking/write_scores.py
@@ -42,7 +42,8 @@ def write_scores_as_json(
             LOG.warning(f"get_scores: {output_file} exists")
             return
         reference_system = utils.ReferenceSystem.from_reference_system(
-            system_dir / scorer_input.reference_system_id, scorer_input.reference_system_id
+            system_dir / scorer_input.reference_system_id,
+            scorer_input.reference_system_id,
         )
         receptor_file = scorer_input.receptor_file
         if np.isnan(receptor_file):

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -10,7 +10,7 @@ from plinder.eval.docking import utils
 
 def test_single_protein_single_ligand_scoring(system_1a3b, predicted_pose_1a3b):
     reference_system = utils.ReferenceSystem.from_reference_system(
-        system_1a3b.parent, system_1a3b.name
+        system_1a3b, system_1a3b.name
     )
     scores = utils.ModelScores.from_files(
         predicted_pose_1a3b.parent.name,
@@ -73,7 +73,7 @@ def test_single_protein_single_ligand_scoring(system_1a3b, predicted_pose_1a3b):
 
 def test_multi_protein_single_ligand_scoring(system_1ai5, predicted_pose_1ai5):
     reference_system = utils.ReferenceSystem.from_reference_system(
-        system_1ai5.parent, system_1ai5.name
+        system_1ai5, system_1ai5.name
     )
     scores = utils.ModelScores.from_files(
         predicted_pose_1ai5.parent.name,


### PR DESCRIPTION
This PR breaks out the previous `run_apo_pred_assignments` pipeline task into two distinct pipeline tasks:
- `make_links`
- `make_linked_structures`
- inside of `make_linked_structures` we additionally isolate:
    - apo/pred pair superposition
    - evaluation metrics
        - update config to set `rigid=False` and pass `full_report=True` to posebusters

and introduces support for multi-node distribution in the workflow whereas previously it needed to be vertically scaled.