### PR TITLE
Fix eval v3000 dative bond issue

### DIFF
--- a/src/plinder/core/index/system.py
+++ b/src/plinder/core/index/system.py
@@ -354,18 +354,15 @@ class PlinderSystem:
 
         ligand_views = {}
         for chain in self.ligand_sdfs:
-            chain_v2000 = make_v2000_from_v3000_sdf(chain)
-            if isinstance(chain_v2000, Path):
+            lig_v2000 = make_v2000_from_v3000_sdf(self.ligand_sdfs[chain])
+            if isinstance(lig_v2000, Path):
                 ligand_views[chain] = io.LoadEntity(
                     self.ligand_sdfs[chain], format="sdf"
                 ).Select("ele != H")
-            elif isinstance(chain_v2000, str):
+            elif isinstance(lig_v2000, str):
                 with tempfile.NamedTemporaryFile(suffix=".sdf") as fp:
-                    fp.write(chain_v2000)
-                    ligand_views.append(
-                        io.LoadEntity(str(fp.name), format="sdf").Select("ele != H")
-                    )
-
+                    fp.write(lig_v2000.encode())
+                    ligand_views[chain] = io.LoadEntity(str(fp.name), format="sdf").Select("ele != H")
         return ligand_views
 
     @property

--- a/src/plinder/core/index/system.py
+++ b/src/plinder/core/index/system.py
@@ -354,7 +354,7 @@ class PlinderSystem:
 
         ligand_views = {}
         for chain in self.ligand_sdfs:
-            lig_v2000 = make_v2000_from_v3000_sdf(self.ligand_sdfs[chain])
+            lig_v2000 = make_v2000_from_v3000_sdf(Path(self.ligand_sdfs[chain]))
             if isinstance(lig_v2000, Path):
                 ligand_views[chain] = io.LoadEntity(
                     self.ligand_sdfs[chain], format="sdf"

--- a/src/plinder/core/index/system.py
+++ b/src/plinder/core/index/system.py
@@ -362,7 +362,9 @@ class PlinderSystem:
             elif isinstance(lig_v2000, str):
                 with tempfile.NamedTemporaryFile(suffix=".sdf") as fp:
                     fp.write(lig_v2000.encode())
-                    ligand_views[chain] = io.LoadEntity(str(fp.name), format="sdf").Select("ele != H")
+                    ligand_views[chain] = io.LoadEntity(
+                        str(fp.name), format="sdf"
+                    ).Select("ele != H")
         return ligand_views
 
     @property

--- a/src/plinder/core/structure/atoms.py
+++ b/src/plinder/core/structure/atoms.py
@@ -15,6 +15,7 @@ from biotite.structure.io.pdbx import get_structure
 from numpy.typing import NDArray
 from rdkit import Chem
 from rdkit.Chem import AllChem, Mol, rdDepictor, rdMolDescriptors, rdRascalMCES
+from rdkit.Chem.rdchem import BondType
 
 from plinder.core.structure.vendored import (
     _convert_resn_to_sequence_and_numbering,
@@ -387,3 +388,15 @@ def _sequence_full_atom_type_array(
                 feat.append(_convert_pdb_atom_name_to_elem_symbol(atom))
         seq_atom_dict[chain] = np.array(feat)
     return seq_atom_dict
+
+
+def make_v2000_from_v3000_sdf(sdf_path: Path) -> Path | str:
+    mol = next(Chem.SDMolSupplier(sdf_path))
+    unmodified_mol_block = Chem.MolToMolBlock(mol)
+    if "V3000" in unmodified_mol_block:
+        for b in mol.GetBonds():
+            if b.GetBondType() == BondType.DATIVE:
+                b.SetBondType(BondType.UNSPECIFIED)
+        return Chem.MolToMolBlock(mol)
+    else:
+        return sdf_path

--- a/src/plinder/core/structure/atoms.py
+++ b/src/plinder/core/structure/atoms.py
@@ -397,6 +397,7 @@ def make_v2000_from_v3000_sdf(sdf_path: Path) -> Path | str:
         for b in mol.GetBonds():
             if b.GetBondType() == BondType.DATIVE:
                 b.SetBondType(BondType.UNSPECIFIED)
-        return Chem.MolToMolBlock(mol)
+        mol_block: str = Chem.MolToMolBlock(mol)
+        return mol_block
     else:
         return sdf_path

--- a/src/plinder/core/structure/atoms.py
+++ b/src/plinder/core/structure/atoms.py
@@ -391,7 +391,7 @@ def _sequence_full_atom_type_array(
 
 
 def make_v2000_from_v3000_sdf(sdf_path: Path) -> Path | str:
-    mol = next(Chem.SDMolSupplier(sdf_path))
+    mol = next(Chem.SDMolSupplier(str(sdf_path)))
     unmodified_mol_block = Chem.MolToMolBlock(mol)
     if "V3000" in unmodified_mol_block:
         for b in mol.GetBonds():

--- a/src/plinder/eval/docking/utils.py
+++ b/src/plinder/eval/docking/utils.py
@@ -88,6 +88,7 @@ class ComplexData:
             entity = io.LoadPDB(receptor_file.as_posix(), fault_tolerant=True)
         ligand_views = []
         for ligand_sdf_file in ligand_files:
+            # change DATIVE BOND -> UNSPECIFIED
             ligand_sdf_file_v2000 = make_v2000_from_v3000_sdf(ligand_sdf_file)
             if isinstance(ligand_sdf_file_v2000, Path):
                 ligand_views.append(

--- a/src/plinder/eval/docking/utils.py
+++ b/src/plinder/eval/docking/utils.py
@@ -95,7 +95,7 @@ class ComplexData:
                 )
             elif isinstance(ligand_sdf_file_v2000, str):
                 with tempfile.NamedTemporaryFile(suffix=".sdf") as fp:
-                    fp.write(ligand_sdf_file_v2000)
+                    fp.write(ligand_sdf_file_v2000.encode())
                     ligand_views.append(
                         io.LoadEntity(str(fp.name), format="sdf").Select("ele != H")
                     )


### PR DESCRIPTION
Context: 
rdkit automatically saves any molecule with dative bond (e.g HEM) automatically as v3000 sdf.
However, `ost` can't load v3000 files with DATIVE bond. Throws `Exception: Bad bond line 100: Bond type number '9' not within accepted range (1-8).`

Fix: 
Change DATIVE bond to UNSPECIFIED on the fly