### PR TITLE
Build docs for new tags

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,8 +1,8 @@
 name: Documentation
 on:
   push:
-    branches:
-     - main
+    tags:
+      - v*.*.*
 
 permissions:
   id-token: write
@@ -32,11 +32,8 @@ jobs:
           cache-downloads: true
           cache-environment: true
           post-cleanup: all
-      - name: Install build and tag requirements
-        run: python -m pip install build semver
-      - name: Get version bump
-        id: get-tag
-        run: git tag $(python flows/docker.py bump)
+      - name: Install package
+        run: pip install .
       - name: Build docs
         shell: bash -el {0}
         id: build


### PR DESCRIPTION
This PR makes the CI build the documentation after git tag was created and thus fixes #73.