### PR TITLE
Fix: set local context to avoid errors resetting global start method

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,7 +4,7 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
-  
+
 permissions:
   id-token: write
   contents: read

--- a/src/plinder/eval/docking/write_scores.py
+++ b/src/plinder/eval/docking/write_scores.py
@@ -212,8 +212,8 @@ def score_test_set(
         )
         predictions = predictions[~predictions["exists"]]
     LOG.info(f"Running evaluation on {predictions.shape[0]} cases")
-    multiprocessing.set_start_method("spawn")
-    with multiprocessing.Pool(num_processes) as p:
+    ctx = multiprocessing.get_context("spawn")
+    with ctx.Pool(num_processes) as p:
         p.starmap(
             write_scores_as_json,
             [


### PR DESCRIPTION
Closed the previous PR and reopened a new one because the contrib_dev branch has been deleted in the last couple of days, so I'm merging to main (I hope this is fine, let me know if you prefer the contribution to be merged elsewhere).

This PR is to solve issue #88 to avoid setting the global context multiple times.