### PR TITLE
bugfix: one aggregate score per model + pin networkit==11.0.0

### DIFF
--- a/docs/contribution/development.md
+++ b/docs/contribution/development.md
@@ -30,7 +30,7 @@ We currently only support a Linux environment.
 `plinder.data` uses a number of dependencies which are not simply pip-installable.
 `openstructure` is for some of its functionality and is available from the
 `aivant` conda channel using `conda install aivant::openstructure`, but it is only built
-targeting Linux architectures. Additionally, `networkit==11.0`, which at the time of writing,
+targeting Linux architectures. Additionally, `networkit==11.0.0`, which at the time of writing,
 does not install cleanly on MacOS, along with a number of dependencies which are referenced
 by a GitHub link directly, make a pip-installable package problematic. These additional
 dependencies can be installed by running:

--- a/docs/contribution/development.md
+++ b/docs/contribution/development.md
@@ -30,7 +30,7 @@ We currently only support a Linux environment.
 `plinder.data` uses a number of dependencies which are not simply pip-installable.
 `openstructure` is for some of its functionality and is available from the
 `aivant` conda channel using `conda install aivant::openstructure`, but it is only built
-targeting Linux architectures. Additionally, `networkit>=11.0`, which at the time of writing,
+targeting Linux architectures. Additionally, `networkit==11.0`, which at the time of writing,
 does not install cleanly on MacOS, along with a number of dependencies which are referenced
 by a GitHub link directly, make a pip-installable package problematic. These additional
 dependencies can be installed by running:

--- a/requirements_data.txt
+++ b/requirements_data.txt
@@ -1,4 +1,4 @@
-  networkit == 11.0
+  networkit == 11.0.0
   tabulate
   pdb-validation @ git+https://git.scicore.unibas.ch/schwede/ligand-validation.git
   mmpdb @ git+https://github.com/rdkit/mmpdb.git

--- a/requirements_data.txt
+++ b/requirements_data.txt
@@ -1,4 +1,4 @@
-  networkit >= 11.0
+  networkit == 11.0
   tabulate
   pdb-validation @ git+https://git.scicore.unibas.ch/schwede/ligand-validation.git
   mmpdb @ git+https://github.com/rdkit/mmpdb.git

--- a/src/plinder/data/__init__.py
+++ b/src/plinder/data/__init__.py
@@ -9,7 +9,7 @@ except (ImportError, ModuleNotFoundError):
     raise ImportError(
         dedent(
             """\
-            plinder.data requires the OpenStructureToolkit >= 2.8.0 (ost) and networkit >= 11.0 to be installed.
+            plinder.data requires the OpenStructureToolkit >= 2.8.0 (ost) and networkit == 11.0 to be installed.
             Please refer to the documentation for installation instructions and current limitations.
             See details here:
 

--- a/src/plinder/data/__init__.py
+++ b/src/plinder/data/__init__.py
@@ -9,7 +9,7 @@ except (ImportError, ModuleNotFoundError):
     raise ImportError(
         dedent(
             """\
-            plinder.data requires the OpenStructureToolkit >= 2.8.0 (ost) and networkit == 11.0 to be installed.
+            plinder.data requires the OpenStructureToolkit >= 2.8.0 (ost) and networkit == 11.0.0 to be installed.
             Please refer to the documentation for installation instructions and current limitations.
             See details here:
 

--- a/src/plinder/eval/docking/make_plots.py
+++ b/src/plinder/eval/docking/make_plots.py
@@ -43,8 +43,11 @@ class EvaluationResults:
     def from_scores_and_data_files(
         cls, score_file: Path, data_file: Path, output_dir: Path, top_n: int = 10
     ) -> "EvaluationResults":
-        # use only one score per system when plotting aggregated scores
-        scores_df = pd.read_parquet(score_file).drop_duplicates("reference")
+        # for eval we use aggregate (wave) scores
+        # multi ligand systems have them duplicated per each ligand entry
+        # drop them to avoid multiple counting when socring the same pose
+        # i.e. keep one aggregate score (wave) per model
+        scores_df = pd.read_parquet(score_file).drop_duplicates(["reference", "rank"])
         data_df = pd.read_parquet(data_file)
         merged_df = scores_df[scores_df["reference"].isin(data_df["system_id"])].merge(
             data_df, left_on="reference", right_on="system_id", how="left"

--- a/src/plinder/eval/docking/make_plots.py
+++ b/src/plinder/eval/docking/make_plots.py
@@ -45,7 +45,7 @@ class EvaluationResults:
     ) -> "EvaluationResults":
         # for eval we use aggregate (wave) scores
         # multi ligand systems have them duplicated per each ligand entry
-        # drop them to avoid multiple counting when socring the same pose
+        # drop them to avoid multiple counting when scoring the same pose
         # i.e. keep one aggregate score (wave) per model
         scores_df = pd.read_parquet(score_file).drop_duplicates(["reference", "rank"])
         data_df = pd.read_parquet(data_file)


### PR DESCRIPTION
For eval we use aggregate (weighed average or "wave") scores. In multi ligand systems we have them duplicated per each ligand entry.

Bug was introduced in [PR#74](https://github.com/plinder-org/plinder/pull/74/files#diff-38a6931550de10684a3bbe420dca9d930c0f2d3680b439a067057ab078f34c6fR46-R47) when dropping these duplicate values to avoid multiple counting for multi-ligand systems.
By accident this was dropping values from all the different ranks, too. Bug spotted by @DreRnc and reported in ISSUE https://github.com/plinder-org/plinder/issues/97

This PR should fix the above issue while maintaining the logic for multi ligand eval.

--- 
Additionally, with networkit new release [11.0.1 on Feb 13, 2025](https://pypi.org/project/networkit/4.0/#history) - `test_make_components_and_communities` [fails](https://github.com/plinder-org/plinder/actions/runs/13367571308/job/37328682055#step:10:387).


Temporarily add pin for the functional version: `networkit==11.0.0`.