### PR TITLE
Add missing `atom3d` dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "plinder"
 dynamic = ["version"]
 dependencies = [
+    "atom3d",
     "biotite >= 1.0",
     "numpy<2",
     "pandas",


### PR DESCRIPTION
* Adds the missing `atom3d` dependency to pyproject.toml