### PR TITLE
upgrade to numpy2 and python3.12

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -3,7 +3,7 @@ Copyright (c) 2024, Plinder Development Team
 
 The PLINDER project is a collaboration between the
 University of Basel, SIB Swiss Institute of Bioinformatics,
-VantAI, NVIDIA, and MIT CSAIL.
+Proxima (formerly VantAI), NVIDIA, and MIT CSAIL.
 
 If you find this software useful, please cite:
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ resource for training and evaluation of protein-ligand docking algorithms:
   models.
 
 The *PLINDER* project is a community effort, launched by the University of Basel,
-SIB Swiss Institute of Bioinformatics, VantAI, NVIDIA, MIT CSAIL, and will be regularly
-updated.
+SIB Swiss Institute of Bioinformatics, Proxima (formerly VantAI), NVIDIA, MIT CSAIL,
+and will be regularly updated.
 
 To accelerate community adoption, PLINDER will be used as the field’s new Protein-Ligand
 interaction dataset standard as part of an exciting competition at the upcoming 2024

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -56,6 +56,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
     && rm -rf /var/lib/apt/lists/*
 
 ENV BASH_ENV=/usr/local/bin/_activate_current_env.sh
+ENV LD_LIBRARY_PATH=/opt/conda/lib
 
 COPY requirements.txt /tmp/requirements.txt
 RUN --mount=type=secret,id=INDEX_URL \

--- a/dockerfiles/base/env.yml
+++ b/dockerfiles/base/env.yml
@@ -1,8 +1,6 @@
 name: base
 channels:
-  - metalcycling
   - conda-forge
-  - aivant
   - defaults
   - bioconda
 dependencies:
@@ -12,8 +10,7 @@ dependencies:
   - google-cloud-storage
   - gcsfs
   - reduce
-  - aivant::openstructure=2.8.0
-  - boost=1.82
+  - openstructure
   - mmseqs2
   - foldseek
   - plip=2.3.0

--- a/dockerfiles/base/env.yml
+++ b/dockerfiles/base/env.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
   - bioconda
 dependencies:
-  - python=3.10.*
+  - python=3.12.*
   - pyopenssl=23.2.0
   - requests=2.25.1
   - google-cloud-storage

--- a/docs/contribution/development.md
+++ b/docs/contribution/development.md
@@ -53,7 +53,7 @@ $ mamba activate plinder
 Now `plinder` can be installed into the created environment:
 
 ```console
-$ pip install -e .
+$ pip install -e ".[dev]"
 ```
 
 ### Enabling Pre-commit hooks

--- a/docs/contribution/development.md
+++ b/docs/contribution/development.md
@@ -26,14 +26,13 @@ Afterwards the environment can be created from the `environment.yml` in the loca
 repository clone.
 
 :::{note}
-We currently only support a Linux environment.
+Currently only a Linux environment is fully supported, although the base
+environment also installs to MacOS.
 `plinder.data` uses a number of dependencies which are not simply pip-installable.
-`openstructure` is for some of its functionality and is available from the
-`aivant` conda channel using `conda install aivant::openstructure`, but it is only built
-targeting Linux architectures. Additionally, `networkit==11.0.0`, which at the time of writing,
-does not install cleanly on MacOS, along with a number of dependencies which are referenced
-by a GitHub link directly, make a pip-installable package problematic. These additional
-dependencies can be installed by running:
+Several dependencies which are referenced by a GitHub link directly, make
+a pip-installable package problematic.
+This includes Linux pytorch, which will not work in MacOS.
+These additional dependencies can be installed by running:
 
 ```console
 $ pip install -r requirements_data.txt

--- a/docs/contribution/index.md
+++ b/docs/contribution/index.md
@@ -1,8 +1,8 @@
 # Contributor guide
 
 The PLINDER project is a community effort, launched by the University of Basel,
-SIB Swiss Institute of Bioinformatics, Proxima (formerly VantAI), NVIDIA, MIT CSAIL, and will be regularly
-updated.
+SIB Swiss Institute of Bioinformatics, Proxima (formerly VantAI), NVIDIA, MIT CSAIL,
+and will be regularly updated.
 We highly welcome contributions!
 
 This guide gives an introduction about how to maintain and improve `plinder` as

--- a/docs/contribution/index.md
+++ b/docs/contribution/index.md
@@ -1,7 +1,7 @@
 # Contributor guide
 
 The PLINDER project is a community effort, launched by the University of Basel,
-SIB Swiss Institute of Bioinformatics, VantAI, NVIDIA, MIT CSAIL, and will be regularly
+SIB Swiss Institute of Bioinformatics, Proxima (formerly VantAI), NVIDIA, MIT CSAIL, and will be regularly
 updated.
 We highly welcome contributions!
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,16 +3,13 @@
 #
 name: plinder
 channels:
-  - metalcycling
   - conda-forge
-  - aivant
   - defaults
   - bioconda
 dependencies:
   - python=3.10.*
   - reduce
-  - aivant::openstructure=2.8.0
-  - boost=1.82
+  - openstructure
   - mmseqs2
   - foldseek
   - plip=2.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,8 @@ test = [
     "pytest == 7.2.0",
     "pytest-cov == 4.0.0",
     "pytest-xdist == 3.6.1",
-    "build == 0.9.0",
-    "setuptools_scm[toml] == 7.0.5",
+    "build",
+    "setuptools_scm[toml]",
 ]
 type = [
     "mypy==1.2.0",
@@ -94,9 +94,9 @@ docs = [
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    "build == 0.9.0",
-    "setuptools == 65.4.0",
-    "setuptools_scm[toml] == 7.0.5",
+    "build",
+    "setuptools",
+    "setuptools_scm[toml]",
 ]
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "plinder"
 dynamic = ["version"]
 dependencies = [
     "biotite >= 1.0",
-    "numpy<2",
+    "numpy",
     "pandas",
     "typing_extensions",
     "pydantic",

--- a/requirements_data.txt
+++ b/requirements_data.txt
@@ -1,4 +1,4 @@
-  networkit >= 11.0
+  networkit > 11.0
   tabulate
   pdb-validation @ git+https://git.scicore.unibas.ch/schwede/ligand-validation.git
   mmpdb @ git+https://github.com/rdkit/mmpdb.git

--- a/requirements_data.txt
+++ b/requirements_data.txt
@@ -2,4 +2,4 @@
   tabulate
   pdb-validation @ git+https://git.scicore.unibas.ch/schwede/ligand-validation.git
   mmpdb @ git+https://github.com/rdkit/mmpdb.git
-  https://download.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp310-cp310-linux_x86_64.whl#sha256=7f91a2200e352745d70e22396bd501448e28350fbdbd8d8b1c83037e25451150
+  https://download.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp312-cp312-linux_x86_64.whl#sha256=4856f9d6925121d13c2df07aa7580b767f449dfe71ae5acde9c27535d5da4840

--- a/requirements_data.txt
+++ b/requirements_data.txt
@@ -1,4 +1,4 @@
-  networkit == 11.0.0
+  networkit >= 11.0
   tabulate
   pdb-validation @ git+https://git.scicore.unibas.ch/schwede/ligand-validation.git
   mmpdb @ git+https://github.com/rdkit/mmpdb.git

--- a/src/plinder/__init__.py
+++ b/src/plinder/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2024, Plinder Development Team
 # Distributed under the terms of the Apache License 2.0
+"""plinder"""
 from pathlib import Path
 
 from ._version import _get_version

--- a/tests/core/test_core_system.py
+++ b/tests/core/test_core_system.py
@@ -38,7 +38,7 @@ def test_plinder_system_fails(system_id, read_plinder_mount):
 def test_plinder_system_system_files(read_plinder_mount):
     system_id = "19hc__1__1.A_1.B__1.V_1.X_1.Y"
     s = index.PlinderSystem(system_id=system_id)
-    assert len(s.structures) == 9
+    assert len(s.structures) == 10
     assert len(s.ligand_sdfs) == 3
     assert len(s.system_cif)
     assert len(s.receptor_cif)

--- a/tests/core/test_core_system.py
+++ b/tests/core/test_core_system.py
@@ -38,7 +38,7 @@ def test_plinder_system_fails(system_id, read_plinder_mount):
 def test_plinder_system_system_files(read_plinder_mount):
     system_id = "19hc__1__1.A_1.B__1.V_1.X_1.Y"
     s = index.PlinderSystem(system_id=system_id)
-    assert len(s.structures) == 10
+    assert len(s.structures) == 9
     assert len(s.ligand_sdfs) == 3
     assert len(s.system_cif)
     assert len(s.receptor_cif)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -6645,7 +6645,9 @@ def test_smiles_from_nextgen(test_dir, smiles_sample_csv):
     # Canonicalize SMILES to absorb differences across OST versions
     for df in [result_df, target_df]:
         df["smiles"] = df["smiles"].apply(
-            lambda s: Chem.MolToSmiles(Chem.MolFromSmiles(s)) if Chem.MolFromSmiles(s) is not None else s
+            lambda s: Chem.MolToSmiles(Chem.MolFromSmiles(s))
+            if Chem.MolFromSmiles(s) is not None
+            else s
         )
     pd.testing.assert_frame_equal(result_df, target_df)
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -6380,7 +6380,7 @@ def test_synthetic_cov_peptide_detection(cif_6lu7, mock_alternative_datasets):
     assert lig.covalent_linkages == {"145:CYS:A:145:SG__5:PJE:B:5:C20"}
     outsdffile = entry_dir / "6lu7__1__1.A_2.A__1.B/ligand_files/1.B.sdf"
     assert outsdffile.is_file()
-    rdmol = Chem.SDMolSupplier(outsdffile, removeHs=True)[0]
+    rdmol = Chem.SDMolSupplier(str(outsdffile), removeHs=True)[0]
     assert Chem.SanitizeMol(rdmol) == Chem.rdmolops.SanitizeFlags.SANITIZE_NONE
     assert len(Chem.MolToSmiles(rdmol).split(".")) == 1
 
@@ -6642,6 +6642,11 @@ def test_smiles_from_nextgen(test_dir, smiles_sample_csv):
     result_df = result_df.sort_values(by=["pdbid", "chain"]).reset_index(drop=True)
     target_df = pd.read_csv(smiles_sample_csv)
     target_df = target_df.sort_values(by=["pdbid", "chain"]).reset_index(drop=True)
+    # Canonicalize SMILES to absorb differences across OST versions
+    for df in [result_df, target_df]:
+        df["smiles"] = df["smiles"].apply(
+            lambda s: Chem.MolToSmiles(Chem.MolFromSmiles(s)) if Chem.MolFromSmiles(s) is not None else s
+        )
     pd.testing.assert_frame_equal(result_df, target_df)
 
 
@@ -6719,7 +6724,7 @@ def test_ligand_fix_to_valid_imatinib(cif_2hyy, mock_alternative_datasets):
     assert lig.is_invalid == False
     outsdffile = entry_dir / "2hyy__1__1.A__1.E/ligand_files/1.E.sdf"
     assert outsdffile.is_file()
-    rdmol_sdf = Chem.SDMolSupplier(outsdffile, removeHs=True)[0]
+    rdmol_sdf = Chem.SDMolSupplier(str(outsdffile), removeHs=True)[0]
     rdmol_smi = Chem.MolFromSmiles(lig.smiles)
     # check that numnber of aromatic rings is undderstood correctly
     # N.B. this is expected to be true for fully resolved systems
@@ -6738,7 +6743,7 @@ def test_ligand_fix_to_valid_thalidomide(cif_7bqu, mock_alternative_datasets):
     assert lig.is_invalid == False
     outsdffile = entry_dir / "7bqu__1__1.A_1.B__1.C/ligand_files/1.C.sdf"
     assert outsdffile.is_file()
-    rdmol_sdf = Chem.SDMolSupplier(outsdffile, removeHs=True)[0]
+    rdmol_sdf = Chem.SDMolSupplier(str(outsdffile), removeHs=True)[0]
     rdmol_smi = Chem.MolFromSmiles(lig.smiles)
     # check that numnber of aromatic rings is undderstood correctly
     # N.B. this is expected to be true for fully resolved systems
@@ -6758,7 +6763,7 @@ def test_partially_resolved_substructure_JEF(cif_1ngx, mock_alternative_datasets
     assert lig.num_unresolved_heavy_atoms == 13
     outsdffile = entry_dir / "1ngx__1__1.A_1.B__1.E/ligand_files/1.E.sdf"
     assert outsdffile.is_file()
-    rdmol = Chem.SDMolSupplier(outsdffile, removeHs=True)[0]
+    rdmol = Chem.SDMolSupplier(str(outsdffile), removeHs=True)[0]
     assert Chem.SanitizeMol(rdmol) == Chem.rdmolops.SanitizeFlags.SANITIZE_NONE
     rdmol_smi = Chem.MolFromSmiles(lig.smiles)
     substruct_matches = rdmol_smi.GetSubstructMatches(rdmol)
@@ -6776,7 +6781,7 @@ def test_distorted_molecule_template_fix(cif_3grt, mock_alternative_datasets):
     assert lig.is_invalid == False
     outsdffile = entry_dir / "3grt__1__1.A_2.A__1.B/ligand_files/1.B.sdf"
     assert outsdffile.is_file()
-    rdmol = Chem.SDMolSupplier(outsdffile, removeHs=True)[0]
+    rdmol = Chem.SDMolSupplier(str(outsdffile), removeHs=True)[0]
     assert Chem.SanitizeMol(rdmol) == Chem.rdmolops.SanitizeFlags.SANITIZE_NONE
 
 
@@ -6789,7 +6794,7 @@ def test_hydrogen_removed_save(cif_7az3, mock_alternative_datasets):
     pli_entry = list(entry.systems.keys())[0]
     outsdffile = entry_dir / pli_entry / f"ligand_files/{pli_entry[-3:]}.sdf"
     assert outsdffile.is_file()
-    rdmol = Chem.SDMolSupplier(outsdffile, removeHs=False, sanitize=False)[0]
+    rdmol = Chem.SDMolSupplier(str(outsdffile), removeHs=False, sanitize=False)[0]
     assert sum([at.GetAtomicNum() == 1 for at in rdmol.GetAtoms()]) == 0
     assert Chem.SanitizeMol(rdmol) == Chem.rdmolops.SanitizeFlags.SANITIZE_NONE
 
@@ -6803,7 +6808,7 @@ def test_too_many_hydrogens(cif_6ntj, mock_alternative_datasets):
     pli_entry = list(entry.systems.keys())[0]
     outsdffile = entry_dir / pli_entry / f"ligand_files/{pli_entry[-3:]}.sdf"
     assert outsdffile.is_file()
-    rdmol = Chem.SDMolSupplier(outsdffile, removeHs=False, sanitize=False)[0]
+    rdmol = Chem.SDMolSupplier(str(outsdffile), removeHs=False, sanitize=False)[0]
     assert sum([at.GetAtomicNum() == 1 for at in rdmol.GetAtoms()]) == 0
     assert Chem.SanitizeMol(rdmol) == Chem.rdmolops.SanitizeFlags.SANITIZE_NONE
 
@@ -6815,7 +6820,7 @@ def test_disconnected_ligand_fix(cif_4nhc, mock_alternative_datasets):
     assert lig.is_invalid == False
     outsdffile = entry_dir / "4nhc__1__1.A_1.B__1.C/ligand_files/1.C.sdf"
     assert outsdffile.is_file()
-    rdmol = Chem.SDMolSupplier(outsdffile, removeHs=True)[0]
+    rdmol = Chem.SDMolSupplier(str(outsdffile), removeHs=True)[0]
     assert Chem.SanitizeMol(rdmol) == Chem.rdmolops.SanitizeFlags.SANITIZE_NONE
     assert len(Chem.MolToSmiles(rdmol).split(".")) == 1
 


### PR DESCRIPTION
Relieving the pains of this issue #111 !

Undoing the damage of PR https://github.com/plinder-org/plinder/pull/98 that pinned `numpy<2` due to issues with `networkit=11.0.0`. This has since been [remedied](https://github.com/networkit/networkit/issues/1243#issuecomment-2658624344).